### PR TITLE
feat: three-layer killbits policy surface on Imageflow.Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 *.userosscache
 *.sln.docstates
 
+# Agent coordination marker (never committed)
+.workongoing
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/docs/killbits.md
+++ b/docs/killbits.md
@@ -1,0 +1,185 @@
+# Killbits — format and codec gating
+
+Imageflow Server ships a three-layer killbits system that lets operators narrow which image formats and named codecs can decode or encode on their server.
+
+The three layers are:
+
+1. **Compile ceiling** — set by which features the native imageflow runtime was built with. Can only deny; never widens.
+2. **Trusted policy** — set once at server startup from `Imageflow:Security` in configuration. Narrows the compile ceiling.
+3. **Per-job security** — attached to each request before it crosses to the native side. Can only narrow further; can never widen.
+
+A format or codec is only usable when **every** layer allows it.
+
+## Default behavior
+
+By default, Imageflow Server denies **AVIF encode** and **JXL encode** even when the native build supports them. Operators must explicitly opt in. This is a deliberate change from previous releases, where anything the native build included was enabled.
+
+You can see the default list without reading source: `Imageflow.Server.SecurityPolicyOptions.ServerRiskyEncodeDefault`.
+
+Decode is not restricted by the server default — only encode.
+
+## Enabling the killbits surface
+
+Add a `Security` block under `Imageflow` in `appsettings.json`:
+
+```jsonc
+{
+  "Imageflow": {
+    "Security": {
+      "MaxDecodeSize": { "W": 8000, "H": 8000, "Megapixels": 50 },
+      "MaxInputFileBytes": 268435456,
+      "MaxJsonBytes": 67108864,
+
+      "Formats": {
+        "OptInEncode": [ "avif", "jxl" ]
+      },
+
+      "Codecs": {
+        "DenyEncoders": [ "mozjpeg_encoder" ]
+      }
+    }
+  }
+}
+```
+
+Bind it into the middleware options once at startup:
+
+```csharp
+var policy = SecurityPolicyConfigurationBinder.Bind(
+    configuration.GetSection(SecurityPolicyConfigurationBinder.DefaultSectionPath));
+
+app.UseImageflow(new ImageflowMiddlewareOptions()
+    // ... existing config ...
+    .SetSecurityPolicyOptions(policy));
+```
+
+If `SecurityPolicyOptions` is `null` (no `Imageflow:Security` section), the server behaves exactly like previous releases — no policy is sent to the native runtime and no server-default deny list is applied.
+
+## Turning AVIF / JXL encoding on
+
+List the formats you want to allow under `Formats:OptInEncode`:
+
+```jsonc
+{
+  "Imageflow": {
+    "Security": {
+      "Formats": {
+        "OptInEncode": [ "avif" ]
+      }
+    }
+  }
+}
+```
+
+AVIF encode will now be allowed. JXL encode stays denied (because it's still on the server's risky-encode list and not opted into). The opposite is also fine:
+
+```jsonc
+"OptInEncode": [ "jxl" ]
+```
+
+allows JXL while AVIF remains denied.
+
+## Expressing policy via allow-list, deny-list, or table
+
+Three mutually-exclusive shapes are accepted under `Formats`:
+
+### Allow-list — only these formats are usable
+
+```jsonc
+"Formats": {
+  "AllowEncode": [ "jpeg", "png", "webp" ],
+  "AllowDecode": [ "jpeg", "png", "webp", "gif" ]
+}
+```
+
+When you use an allow-list, the server default does **not** apply — you've taken explicit control. Anything not on your list is denied.
+
+### Deny-list — everything except these
+
+```jsonc
+"Formats": {
+  "DenyEncode": [ "webp" ]
+}
+```
+
+The server default (AVIF, JXL) is merged into your list: the final deny list becomes `[avif, jxl, webp]`. Use `OptInEncode` to subtract from the server default:
+
+```jsonc
+"Formats": {
+  "OptInEncode": [ "avif" ],
+  "DenyEncode":  [ "webp" ]
+}
+```
+
+Effective deny list: `[jxl, webp]`. AVIF is opted in; JXL is still denied.
+
+### Table form — explicit per-format decode/encode flags
+
+```jsonc
+"Formats": {
+  "Formats": {
+    "avif": { "Decode": true, "Encode": true },
+    "jxl":  { "Decode": true, "Encode": false }
+  }
+}
+```
+
+Any format you mention is operator-controlled — the server default no longer applies to it. Formats you don't mention inherit the server default; unmentioned risky formats are injected into the table as encode-false entries.
+
+## Named codec gating
+
+Use `Codecs` to allow or deny specific named encoder / decoder backends:
+
+```jsonc
+"Codecs": {
+  "DenyEncoders": [ "mozjpeg_encoder" ]
+}
+```
+
+The codec names are snake_case and match the native imageflow enum. Use `allow_*` / `deny_*` pairs:
+
+- `AllowEncoders` / `DenyEncoders` — mutually exclusive
+- `AllowDecoders` / `DenyDecoders` — mutually exclusive
+
+## Diagnosing "why not WebP?"
+
+On startup, the server logs a single structured line tagged `killbits-policy` summarizing the effective grid:
+
+```
+killbits-policy server_risky_encode=[avif,jxl] decode_allowed=[jpeg,png,gif,webp,avif,jxl,bmp,tiff,pnm] encode_allowed=[jpeg,png,gif,webp] trusted_policy_set=True
+```
+
+`grep killbits-policy` in your log to answer "which codecs are enabled" without reading source.
+
+For deeper diagnostics, enable the response header:
+
+```csharp
+options.SetExposeNetSupportHeader(true);
+```
+
+Responses will carry `X-Imageflow-Net-Support: formats=jpeg,png,webp,...`. Off by default — the grid is operator-diagnostic information and may leak build details to end users.
+
+## Error shape
+
+When a killbits denial blocks a request, the server returns HTTP 422 with a JSON body:
+
+```json
+{
+  "error": "encode_not_available",
+  "format": "avif",
+  "reasons": [ "denied_by_trusted_policy" ]
+}
+```
+
+The `error` tag is one of `codec_not_available`, `decode_not_available`, or `encode_not_available`. Clients can distinguish these from other 4xx responses (auth, missing file) and surface an appropriate message.
+
+## Invalid configuration
+
+Mutual-exclusion violations (`AllowEncode` + `DenyEncode`, list-form + table-form, etc.) are caught at startup binding time and raise `SecurityPolicyValidationException`. The message points at the offending config path. The server does **not** start in a degraded mode — invalid config means the server doesn't run.
+
+## Reference
+
+- `Imageflow.Server.SecurityPolicyOptions` — the policy shape.
+- `Imageflow.Server.SecurityPolicyConfigurationBinder` — binds from `IConfiguration`.
+- `Imageflow.Server.SecurityPolicyValidator` — the startup validator (used internally).
+- `Imageflow.Server.ImageflowMiddlewareOptions.SetSecurityPolicyOptions` — opt in.

--- a/src/Imageflow.Server/ImageJobInfo.cs
+++ b/src/Imageflow.Server/ImageJobInfo.cs
@@ -430,11 +430,14 @@ namespace Imageflow.Server
                 }
 
                 using var buildJob = new ImageJob();
+                var effectiveSecurity = MergeEffectiveSecurity(
+                    options.JobSecurityOptions,
+                    options.SecurityPolicyValidator?.EffectiveJobSecurity);
                 var jobResult = await buildJob.BuildCommandString(
                         blobs[0].GetMemorySource(),
                         new BytesDestination(), CommandString, watermarks)
                     .Finish()
-                    .SetSecurityOptions(options.JobSecurityOptions)
+                    .SetSecurityOptions(effectiveSecurity)
                     .InProcessAsync();
                 
                 GlobalPerf.Singleton.JobComplete(new ImageJobInstrumentation(jobResult)
@@ -465,6 +468,35 @@ namespace Imageflow.Server
                     b?.Dispose();
                 }
             }
+        }
+
+        /// <summary>
+        /// Combine the legacy per-job <see cref="SecurityOptions"/> with the
+        /// narrowing form derived from
+        /// <see cref="SecurityPolicyOptions"/>. The killbits side always
+        /// wins when both sides specify something (killbits is a hard cap;
+        /// legacy scalar limits fall back only for the fields killbits
+        /// doesn't set).
+        /// </summary>
+        internal static SecurityOptions MergeEffectiveSecurity(
+            SecurityOptions legacy,
+            SecurityOptions fromPolicy)
+        {
+            if (fromPolicy == null) return legacy;
+            if (legacy == null) return fromPolicy;
+
+            var merged = new SecurityOptions
+            {
+                MaxDecodeSize = fromPolicy.MaxDecodeSize ?? legacy.MaxDecodeSize,
+                MaxFrameSize = fromPolicy.MaxFrameSize ?? legacy.MaxFrameSize,
+                MaxEncodeSize = fromPolicy.MaxEncodeSize ?? legacy.MaxEncodeSize,
+                MaxInputFileBytes = fromPolicy.MaxInputFileBytes ?? legacy.MaxInputFileBytes,
+                MaxJsonBytes = fromPolicy.MaxJsonBytes ?? legacy.MaxJsonBytes,
+                MaxTotalFilePixels = fromPolicy.MaxTotalFilePixels ?? legacy.MaxTotalFilePixels,
+                Formats = fromPolicy.Formats,
+                Codecs = fromPolicy.Codecs,
+            };
+            return merged;
         }
     }
     

--- a/src/Imageflow.Server/Imageflow.Server.csproj
+++ b/src/Imageflow.Server/Imageflow.Server.csproj
@@ -19,7 +19,28 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Imageflow.AllPlatforms" Version="0.15.1" />
+    <!--
+      DEV-TIME PIN (feat/killbits-server-integration):
+      Pin to a local ProjectReference on the feat/killbits-dotnet-surface
+      branch of imageflow-dotnet so the killbits surface types
+      (SecurityOptions.Formats / .Codecs, JobContext.SetPolicy,
+      KillbitsDeniedException, etc.) resolve during development.
+
+      Native runtime for dev: pair with Imageflow.NativeRuntime.All 2.3.1-rc01
+      or later (the `imageflow2`-branch rc), which carries
+      v1/context/set_policy + v1/context/get_net_support. Older runtimes will
+      throw ImageflowException with InvalidMessageEndpoint at startup.
+
+      RELEASE PIN (apply before merge):
+      Replace this ProjectReference with the published prerelease once
+      imageflow#720 + imageflow-dotnet#68 ship:
+          <PackageReference Include="Imageflow.AllPlatforms"
+                            Version="[3.0.0-alpha.0, 4.0.0)" />
+      The accept range starts at 3.0.0-alpha.0 so v3 prereleases satisfy the
+      constraint, capped below v4 to catch future major bumps.
+    -->
+    <ProjectReference Include="..\..\..\imageflow-dotnet\src\Imageflow\Imageflow.Net.csproj" />
+    <PackageReference Include="Imageflow.NativeRuntime.All" Version="[2.3.1-rc01, 4.0.0)" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Imageflow.Server/ImageflowMiddleware.cs
+++ b/src/Imageflow.Server/ImageflowMiddleware.cs
@@ -82,6 +82,19 @@ namespace Imageflow.Server
             
             options.Licensing.Initialize(this.options);
 
+            // If the operator configured a three-layer killbits policy,
+            // validate it once on a scratch context, cache the resulting
+            // net-support grid for diagnostics, and stash a narrowing-only
+            // effective SecurityOptions to apply per job. Any failure here
+            // takes down startup — a silent degraded mode would defeat the
+            // point of the killbits surface.
+            if (options.SecurityPolicyOptions != null)
+            {
+                var validator = new SecurityPolicyValidator();
+                validator.Apply(options.SecurityPolicyOptions, this.logger);
+                options.SecurityPolicyValidator = validator;
+            }
+
             blobProvider = new BlobProvider(providers, mappedPaths);
             diagnosticsPage = new DiagnosticsPage(options, env, this.logger, streamCache, this.diskCache, providers);
             licensePage = new LicensePage(options);
@@ -219,6 +232,11 @@ namespace Imageflow.Server
             {
                 await NotFound(context, e);
             }
+            catch (KillbitsDeniedException e)
+            {
+                GlobalPerf.Singleton.IncrementCounter("middleware_killbits_denied");
+                await KillbitsDenied(context, e);
+            }
             catch (Exception e)
             {
                 var errorName = e.GetType().Name;
@@ -236,6 +254,71 @@ namespace Imageflow.Server
                     GlobalPerf.Singleton.IncrementCounter("module_response_ext_" + imageExtension);
                 }
             }
+        }
+
+        private async Task KillbitsDenied(HttpContext context, KillbitsDeniedException e)
+        {
+            // The native side embeds a JSON envelope in the error message
+            // with a structured reasons grid; surface it as HTTP 422 so
+            // clients can distinguish "your format isn't allowed" from
+            // "server is broken".
+            var body = new StringBuilder();
+            body.Append("{\"error\":\"");
+            body.Append(e.DenialKind switch
+            {
+                KillbitsDenialKind.CodecNotAvailable => "codec_not_available",
+                KillbitsDenialKind.DecodeNotAvailable => "decode_not_available",
+                KillbitsDenialKind.EncodeNotAvailable => "encode_not_available",
+                _ => "killbits_denied",
+            });
+            body.Append('"');
+            if (!string.IsNullOrEmpty(e.Codec))
+            {
+                body.Append(",\"codec\":\"").Append(e.Codec).Append('"');
+            }
+            if (!string.IsNullOrEmpty(e.Format))
+            {
+                body.Append(",\"format\":\"").Append(e.Format).Append('"');
+            }
+            if (e.Reasons.Count > 0)
+            {
+                body.Append(",\"reasons\":[");
+                for (var i = 0; i < e.Reasons.Count; i++)
+                {
+                    if (i > 0) body.Append(',');
+                    body.Append('"').Append(e.Reasons[i]).Append('"');
+                }
+                body.Append(']');
+            }
+            body.Append('}');
+
+            context.Response.StatusCode = 422;
+            context.Response.ContentType = "application/json; charset=utf-8";
+            context.Response.Headers[HeaderNames.CacheControl] = "no-store";
+            MaybeEmitNetSupportHeader(context);
+            var bytes = Encoding.UTF8.GetBytes(body.ToString());
+            context.Response.ContentLength = bytes.Length;
+            await context.Response.Body.WriteAsync(bytes, 0, bytes.Length);
+        }
+
+        private void MaybeEmitNetSupportHeader(HttpContext context)
+        {
+            if (!options.ExposeNetSupportHeader) return;
+            var grid = options.SecurityPolicyValidator?.EffectiveNetSupport;
+            if (grid == null) return;
+
+            // Compact form: "formats=jpeg,png,webp;encoders=zen_jpeg_encoder,..."
+            var sb = new StringBuilder();
+            sb.Append("formats=");
+            var first = true;
+            foreach (var kv in grid.Formats)
+            {
+                if (!kv.Value.Encode) continue;
+                if (!first) sb.Append(',');
+                sb.Append(kv.Key);
+                first = false;
+            }
+            context.Response.Headers["X-Imageflow-Net-Support"] = sb.ToString();
         }
 
         private async Task NotAuthorized(HttpContext context, string detail)

--- a/src/Imageflow.Server/ImageflowMiddlewareOptions.cs
+++ b/src/Imageflow.Server/ImageflowMiddlewareOptions.cs
@@ -44,6 +44,31 @@ namespace Imageflow.Server
         
         public RequestSignatureOptions RequestSignatureOptions { get; set; }
         public SecurityOptions JobSecurityOptions { get; set; }
+
+        /// <summary>
+        /// Three-layer killbits policy (applied once at startup via
+        /// <c>v1/context/set_policy</c> for validation, then mirrored into
+        /// every job as narrowing per-job security). Separate from
+        /// <see cref="JobSecurityOptions"/>, which attaches only the scalar
+        /// limits from the old <see cref="SecurityOptions"/> shape to each
+        /// job verbatim.
+        /// </summary>
+        /// <remarks>
+        /// When this is <c>null</c>, the server behaves exactly as pre-killbits
+        /// releases — no <c>SetPolicy</c> call is issued and no narrowing
+        /// mask is applied. Set a value to turn the killbits surface on.
+        /// </remarks>
+        public SecurityPolicyOptions SecurityPolicyOptions { get; set; }
+
+        internal SecurityPolicyValidator SecurityPolicyValidator { get; set; }
+
+        /// <summary>
+        /// Enable the <c>X-Imageflow-Net-Support</c> response header. Off by
+        /// default — the grid is operator-diagnostic information and may leak
+        /// build details to end users. Turn on only for closed-deployment
+        /// debugging.
+        /// </summary>
+        public bool ExposeNetSupportHeader { get; set; }
         
         internal readonly List<UrlHandler<Action<UrlEventArgs>>> Rewrite = new List<UrlHandler<Action<UrlEventArgs>>>();
 
@@ -177,6 +202,27 @@ namespace Imageflow.Server
         public ImageflowMiddlewareOptions SetJobSecurityOptions(SecurityOptions securityOptions)
         {
             JobSecurityOptions = securityOptions;
+            return this;
+        }
+
+        /// <summary>
+        /// Install a three-layer killbits policy. The server validates it at
+        /// startup via <c>v1/context/set_policy</c> on a scratch context and
+        /// applies its effective narrowing form to every job.
+        /// </summary>
+        public ImageflowMiddlewareOptions SetSecurityPolicyOptions(SecurityPolicyOptions policyOptions)
+        {
+            SecurityPolicyOptions = policyOptions;
+            return this;
+        }
+
+        /// <summary>
+        /// Enable the <c>X-Imageflow-Net-Support</c> response header. Off by
+        /// default.
+        /// </summary>
+        public ImageflowMiddlewareOptions SetExposeNetSupportHeader(bool value)
+        {
+            ExposeNetSupportHeader = value;
             return this;
         }
         

--- a/src/Imageflow.Server/PublicAPI.Unshipped.txt
+++ b/src/Imageflow.Server/PublicAPI.Unshipped.txt
@@ -1,0 +1,65 @@
+#nullable enable
+Imageflow.Server.CodecOptions
+Imageflow.Server.CodecOptions.AllowDecoders.get -> System.Collections.Generic.IList<Imageflow.Fluent.NamedDecoderName>?
+Imageflow.Server.CodecOptions.AllowDecoders.set -> void
+Imageflow.Server.CodecOptions.AllowEncoders.get -> System.Collections.Generic.IList<Imageflow.Fluent.NamedEncoderName>?
+Imageflow.Server.CodecOptions.AllowEncoders.set -> void
+Imageflow.Server.CodecOptions.CodecOptions() -> void
+Imageflow.Server.CodecOptions.DenyDecoders.get -> System.Collections.Generic.IList<Imageflow.Fluent.NamedDecoderName>?
+Imageflow.Server.CodecOptions.DenyDecoders.set -> void
+Imageflow.Server.CodecOptions.DenyEncoders.get -> System.Collections.Generic.IList<Imageflow.Fluent.NamedEncoderName>?
+Imageflow.Server.CodecOptions.DenyEncoders.set -> void
+Imageflow.Server.FormatOptions
+Imageflow.Server.FormatOptions.AllowDecode.get -> System.Collections.Generic.IList<Imageflow.Fluent.ImageFormat>?
+Imageflow.Server.FormatOptions.AllowDecode.set -> void
+Imageflow.Server.FormatOptions.AllowEncode.get -> System.Collections.Generic.IList<Imageflow.Fluent.ImageFormat>?
+Imageflow.Server.FormatOptions.AllowEncode.set -> void
+Imageflow.Server.FormatOptions.DenyDecode.get -> System.Collections.Generic.IList<Imageflow.Fluent.ImageFormat>?
+Imageflow.Server.FormatOptions.DenyDecode.set -> void
+Imageflow.Server.FormatOptions.DenyEncode.get -> System.Collections.Generic.IList<Imageflow.Fluent.ImageFormat>?
+Imageflow.Server.FormatOptions.DenyEncode.set -> void
+Imageflow.Server.FormatOptions.FormatOptions() -> void
+Imageflow.Server.FormatOptions.Formats.get -> System.Collections.Generic.IDictionary<Imageflow.Fluent.ImageFormat, Imageflow.Fluent.FormatPermissions>?
+Imageflow.Server.FormatOptions.Formats.set -> void
+Imageflow.Server.FormatOptions.OptInEncode.get -> System.Collections.Generic.IList<Imageflow.Fluent.ImageFormat>?
+Imageflow.Server.FormatOptions.OptInEncode.set -> void
+Imageflow.Server.ImageflowMiddlewareOptions.ExposeNetSupportHeader.get -> bool
+Imageflow.Server.ImageflowMiddlewareOptions.ExposeNetSupportHeader.set -> void
+~Imageflow.Server.ImageflowMiddlewareOptions.SecurityPolicyOptions.get -> Imageflow.Server.SecurityPolicyOptions
+~Imageflow.Server.ImageflowMiddlewareOptions.SecurityPolicyOptions.set -> void
+~Imageflow.Server.ImageflowMiddlewareOptions.SetExposeNetSupportHeader(bool value) -> Imageflow.Server.ImageflowMiddlewareOptions
+~Imageflow.Server.ImageflowMiddlewareOptions.SetSecurityPolicyOptions(Imageflow.Server.SecurityPolicyOptions policyOptions) -> Imageflow.Server.ImageflowMiddlewareOptions
+Imageflow.Server.SecurityPolicyConfigurationBinder
+Imageflow.Server.SecurityPolicyOptions
+Imageflow.Server.SecurityPolicyOptions.BuildEffectiveSecurityOptions() -> Imageflow.Fluent.SecurityOptions!
+Imageflow.Server.SecurityPolicyOptions.Codecs.get -> Imageflow.Server.CodecOptions?
+Imageflow.Server.SecurityPolicyOptions.Codecs.set -> void
+Imageflow.Server.SecurityPolicyOptions.Formats.get -> Imageflow.Server.FormatOptions?
+Imageflow.Server.SecurityPolicyOptions.Formats.set -> void
+Imageflow.Server.SecurityPolicyOptions.MaxDecodeSize.get -> Imageflow.Fluent.FrameSizeLimit?
+Imageflow.Server.SecurityPolicyOptions.MaxDecodeSize.set -> void
+Imageflow.Server.SecurityPolicyOptions.MaxEncodeSize.get -> Imageflow.Fluent.FrameSizeLimit?
+Imageflow.Server.SecurityPolicyOptions.MaxEncodeSize.set -> void
+Imageflow.Server.SecurityPolicyOptions.MaxFrameSize.get -> Imageflow.Fluent.FrameSizeLimit?
+Imageflow.Server.SecurityPolicyOptions.MaxFrameSize.set -> void
+Imageflow.Server.SecurityPolicyOptions.MaxInputFileBytes.get -> ulong?
+Imageflow.Server.SecurityPolicyOptions.MaxInputFileBytes.set -> void
+Imageflow.Server.SecurityPolicyOptions.MaxJsonBytes.get -> ulong?
+Imageflow.Server.SecurityPolicyOptions.MaxJsonBytes.set -> void
+Imageflow.Server.SecurityPolicyOptions.MaxTotalFilePixels.get -> ulong?
+Imageflow.Server.SecurityPolicyOptions.MaxTotalFilePixels.set -> void
+Imageflow.Server.SecurityPolicyOptions.SecurityPolicyOptions() -> void
+Imageflow.Server.SecurityPolicyOptions.ServerRiskyEncode.get -> System.Collections.Generic.IReadOnlyList<Imageflow.Fluent.ImageFormat>!
+Imageflow.Server.SecurityPolicyOptions.ServerRiskyEncode.set -> void
+Imageflow.Server.SecurityPolicyOptions.Validate() -> void
+Imageflow.Server.SecurityPolicyValidationException
+Imageflow.Server.SecurityPolicyValidationException.SecurityPolicyValidationException(string! message) -> void
+Imageflow.Server.SecurityPolicyValidationException.SecurityPolicyValidationException(string! message, System.Exception! inner) -> void
+Imageflow.Server.SecurityPolicyValidator
+Imageflow.Server.SecurityPolicyValidator.Apply(Imageflow.Server.SecurityPolicyOptions! options, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
+Imageflow.Server.SecurityPolicyValidator.EffectiveJobSecurity.get -> Imageflow.Fluent.SecurityOptions?
+Imageflow.Server.SecurityPolicyValidator.EffectiveNetSupport.get -> Imageflow.Bindings.NetSupportResponse?
+Imageflow.Server.SecurityPolicyValidator.SecurityPolicyValidator() -> void
+const Imageflow.Server.SecurityPolicyConfigurationBinder.DefaultSectionPath = "Imageflow:Security" -> string!
+static Imageflow.Server.SecurityPolicyConfigurationBinder.Bind(Microsoft.Extensions.Configuration.IConfiguration! section) -> Imageflow.Server.SecurityPolicyOptions?
+static readonly Imageflow.Server.SecurityPolicyOptions.ServerRiskyEncodeDefault -> System.Collections.Generic.IReadOnlyList<Imageflow.Fluent.ImageFormat>!

--- a/src/Imageflow.Server/SecurityPolicyConfigurationBinder.cs
+++ b/src/Imageflow.Server/SecurityPolicyConfigurationBinder.cs
@@ -1,0 +1,375 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Imageflow.Fluent;
+using Microsoft.Extensions.Configuration;
+
+namespace Imageflow.Server
+{
+    /// <summary>
+    /// Binds <see cref="SecurityPolicyOptions"/> from an
+    /// <see cref="IConfiguration"/> section (typically
+    /// <c>Imageflow:Security</c>).
+    /// </summary>
+    /// <remarks>
+    /// This is deliberately hand-rolled instead of using
+    /// <c>Configuration.Bind</c>. The built-in binder can't easily express
+    /// dictionaries keyed by an enum plus a strongly-typed struct value
+    /// (<see cref="FormatPermissions"/>), and silent binder failures would
+    /// defeat the "fail loudly" goal of the startup validator.
+    ///
+    /// Recognized JSON shape:
+    /// <code>
+    /// {
+    ///   "Imageflow": {
+    ///     "Security": {
+    ///       "MaxDecodeSize": { "W": 8000, "H": 8000, "Megapixels": 50 },
+    ///       "MaxInputFileBytes": 268435456,
+    ///       "MaxJsonBytes": 67108864,
+    ///       "Formats": {
+    ///         "OptInEncode": [ "avif", "jxl" ],
+    ///         "DenyEncode":  [ "webp" ],
+    ///         "AllowDecode": null,
+    ///         "DenyDecode":  null
+    ///       },
+    ///       "Codecs": {
+    ///         "DenyEncoders": [ "mozjpeg_encoder" ]
+    ///       }
+    ///     }
+    ///   }
+    /// }
+    /// </code>
+    /// </remarks>
+    public static class SecurityPolicyConfigurationBinder
+    {
+        /// <summary>Default section path: <c>Imageflow:Security</c>.</summary>
+        public const string DefaultSectionPath = "Imageflow:Security";
+
+        /// <summary>Bind <see cref="SecurityPolicyOptions"/> from <paramref name="section"/>.</summary>
+        /// <returns><c>null</c> when the section doesn't exist (meaning: no security policy configured).</returns>
+        /// <exception cref="SecurityPolicyValidationException">when the config is malformed or inconsistent.</exception>
+        public static SecurityPolicyOptions? Bind(IConfiguration section)
+        {
+            if (section == null)
+            {
+                throw new ArgumentNullException(nameof(section));
+            }
+
+            var opts = new SecurityPolicyOptions();
+            var anyValue = false;
+
+            if (TryReadSize(section.GetSection("MaxDecodeSize"), out var maxDecode))
+            {
+                opts.MaxDecodeSize = maxDecode; anyValue = true;
+            }
+            if (TryReadSize(section.GetSection("MaxFrameSize"), out var maxFrame))
+            {
+                opts.MaxFrameSize = maxFrame; anyValue = true;
+            }
+            if (TryReadSize(section.GetSection("MaxEncodeSize"), out var maxEncode))
+            {
+                opts.MaxEncodeSize = maxEncode; anyValue = true;
+            }
+            if (TryReadUlong(section["MaxInputFileBytes"], nameof(SecurityPolicyOptions.MaxInputFileBytes), out var mibb))
+            {
+                opts.MaxInputFileBytes = mibb; anyValue = true;
+            }
+            if (TryReadUlong(section["MaxJsonBytes"], nameof(SecurityPolicyOptions.MaxJsonBytes), out var mjb))
+            {
+                opts.MaxJsonBytes = mjb; anyValue = true;
+            }
+            if (TryReadUlong(section["MaxTotalFilePixels"], nameof(SecurityPolicyOptions.MaxTotalFilePixels), out var mtfp))
+            {
+                opts.MaxTotalFilePixels = mtfp; anyValue = true;
+            }
+
+            var formatsSection = section.GetSection("Formats");
+            if (formatsSection.Exists())
+            {
+                opts.Formats = BindFormatOptions(formatsSection);
+                anyValue = true;
+            }
+
+            var codecsSection = section.GetSection("Codecs");
+            if (codecsSection.Exists())
+            {
+                opts.Codecs = BindCodecOptions(codecsSection);
+                anyValue = true;
+            }
+
+            // ServerRiskyEncode override — rare, but surfaced so specialized
+            // deployments can change the defaults without replacing
+            // SecurityPolicyOptions wholesale.
+            var riskyValues = ReadFormatList(section.GetSection("ServerRiskyEncode"), "ServerRiskyEncode");
+            if (riskyValues != null)
+            {
+                opts.ServerRiskyEncode = riskyValues;
+                anyValue = true;
+            }
+
+            if (!anyValue)
+            {
+                return null;
+            }
+
+            try
+            {
+                opts.Validate();
+            }
+            catch (SecurityPolicyValidationException)
+            {
+                throw;
+            }
+
+            return opts;
+        }
+
+        private static FormatOptions BindFormatOptions(IConfiguration section)
+        {
+            var opts = new FormatOptions
+            {
+                OptInEncode = ReadFormatList(section.GetSection("OptInEncode"), "Formats:OptInEncode"),
+                AllowDecode = ReadFormatList(section.GetSection("AllowDecode"), "Formats:AllowDecode"),
+                DenyDecode = ReadFormatList(section.GetSection("DenyDecode"), "Formats:DenyDecode"),
+                AllowEncode = ReadFormatList(section.GetSection("AllowEncode"), "Formats:AllowEncode"),
+                DenyEncode = ReadFormatList(section.GetSection("DenyEncode"), "Formats:DenyEncode"),
+            };
+
+            var tableSection = section.GetSection("Formats");
+            if (tableSection.Exists())
+            {
+                var table = new Dictionary<ImageFormat, FormatPermissions>();
+                foreach (var entry in tableSection.GetChildren())
+                {
+                    if (!ImageFormatParser.TryParse(entry.Key, out var format))
+                    {
+                        throw new SecurityPolicyValidationException(
+                            $"Imageflow:Security:Formats:Formats — unknown format '{entry.Key}'. "
+                            + "Expected one of: jpeg, png, gif, webp, avif, jxl, heic, bmp, tiff, pnm.");
+                    }
+                    var decode = ReadBool(entry["Decode"], $"Formats:Formats:{entry.Key}:Decode");
+                    var encode = ReadBool(entry["Encode"], $"Formats:Formats:{entry.Key}:Encode");
+                    table[format] = new FormatPermissions(decode ?? true, encode ?? true);
+                }
+                if (table.Count > 0)
+                {
+                    opts.Formats = table;
+                }
+            }
+
+            return opts;
+        }
+
+        private static CodecOptions BindCodecOptions(IConfiguration section)
+        {
+            return new CodecOptions
+            {
+                AllowEncoders = ReadEncoderList(section.GetSection("AllowEncoders"), "Codecs:AllowEncoders"),
+                DenyEncoders = ReadEncoderList(section.GetSection("DenyEncoders"), "Codecs:DenyEncoders"),
+                AllowDecoders = ReadDecoderList(section.GetSection("AllowDecoders"), "Codecs:AllowDecoders"),
+                DenyDecoders = ReadDecoderList(section.GetSection("DenyDecoders"), "Codecs:DenyDecoders"),
+            };
+        }
+
+        private static List<ImageFormat>? ReadFormatList(IConfigurationSection section, string pathForError)
+        {
+            if (!section.Exists())
+            {
+                return null;
+            }
+            var list = new List<ImageFormat>();
+            foreach (var child in section.GetChildren())
+            {
+                var raw = child.Value;
+                if (string.IsNullOrEmpty(raw))
+                {
+                    continue;
+                }
+                if (!ImageFormatParser.TryParse(raw!.ToLowerInvariant(), out var format))
+                {
+                    throw new SecurityPolicyValidationException(
+                        $"Imageflow:Security:{pathForError} — unknown format '{raw}'. "
+                        + "Expected one of: jpeg, png, gif, webp, avif, jxl, heic, bmp, tiff, pnm.");
+                }
+                list.Add(format);
+            }
+            return list.Count == 0 ? null : list;
+        }
+
+        private static List<NamedEncoderName>? ReadEncoderList(IConfigurationSection section, string pathForError)
+        {
+            if (!section.Exists())
+            {
+                return null;
+            }
+            var list = new List<NamedEncoderName>();
+            foreach (var child in section.GetChildren())
+            {
+                var raw = child.Value;
+                if (string.IsNullOrEmpty(raw))
+                {
+                    continue;
+                }
+                if (!NamedCodecParsers.TryParseEncoder(raw!.ToLowerInvariant(), out var enc))
+                {
+                    throw new SecurityPolicyValidationException(
+                        $"Imageflow:Security:{pathForError} — unknown encoder '{raw}'. "
+                        + "Use snake_case (e.g. 'mozjpeg_encoder').");
+                }
+                list.Add(enc);
+            }
+            return list.Count == 0 ? null : list;
+        }
+
+        private static List<NamedDecoderName>? ReadDecoderList(IConfigurationSection section, string pathForError)
+        {
+            if (!section.Exists())
+            {
+                return null;
+            }
+            var list = new List<NamedDecoderName>();
+            foreach (var child in section.GetChildren())
+            {
+                var raw = child.Value;
+                if (string.IsNullOrEmpty(raw))
+                {
+                    continue;
+                }
+                if (!NamedCodecParsers.TryParseDecoder(raw!.ToLowerInvariant(), out var dec))
+                {
+                    throw new SecurityPolicyValidationException(
+                        $"Imageflow:Security:{pathForError} — unknown decoder '{raw}'. "
+                        + "Use snake_case (e.g. 'zen_png_decoder').");
+                }
+                list.Add(dec);
+            }
+            return list.Count == 0 ? null : list;
+        }
+
+        private static bool TryReadSize(IConfigurationSection section, out FrameSizeLimit? limit)
+        {
+            limit = null;
+            if (!section.Exists())
+            {
+                return false;
+            }
+            var w = TryUint(section["W"]) ?? TryUint(section["Width"]) ?? 0u;
+            var h = TryUint(section["H"]) ?? TryUint(section["Height"]) ?? 0u;
+            var mpRaw = section["Megapixels"] ?? section["MP"];
+            if (!float.TryParse(mpRaw, NumberStyles.Float, CultureInfo.InvariantCulture, out var mp))
+            {
+                mp = 0f;
+            }
+            limit = new FrameSizeLimit(w, h, mp);
+            return true;
+        }
+
+        private static uint? TryUint(string? s) =>
+            uint.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : (uint?)null;
+
+        private static bool TryReadUlong(string? raw, string fieldName, out ulong? value)
+        {
+            value = null;
+            if (string.IsNullOrEmpty(raw))
+            {
+                return false;
+            }
+            if (!ulong.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                throw new SecurityPolicyValidationException(
+                    $"Imageflow:Security:{fieldName} — expected a non-negative integer, got '{raw}'.");
+            }
+            value = parsed;
+            return true;
+        }
+
+        private static bool? ReadBool(string? raw, string pathForError)
+        {
+            if (string.IsNullOrEmpty(raw))
+            {
+                return null;
+            }
+            if (!bool.TryParse(raw, out var b))
+            {
+                throw new SecurityPolicyValidationException(
+                    $"Imageflow:Security:{pathForError} — expected true/false, got '{raw}'.");
+            }
+            return b;
+        }
+    }
+
+    /// <summary>snake_case parser for <see cref="ImageFormat"/>. Mirrors the internal table in imageflow-dotnet.</summary>
+    internal static class ImageFormatParser
+    {
+        public static bool TryParse(string? snakeCase, out ImageFormat format)
+        {
+            switch (snakeCase)
+            {
+                case "jpeg": format = ImageFormat.Jpeg; return true;
+                case "png":  format = ImageFormat.Png;  return true;
+                case "gif":  format = ImageFormat.Gif;  return true;
+                case "webp": format = ImageFormat.Webp; return true;
+                case "avif": format = ImageFormat.Avif; return true;
+                case "jxl":  format = ImageFormat.Jxl;  return true;
+                case "heic": format = ImageFormat.Heic; return true;
+                case "bmp":  format = ImageFormat.Bmp;  return true;
+                case "tiff": format = ImageFormat.Tiff; return true;
+                case "pnm":  format = ImageFormat.Pnm;  return true;
+                default: format = default; return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Name parsers for <see cref="NamedEncoderName"/> / <see cref="NamedDecoderName"/>.
+    /// Exists because the per-enum <c>TryParse</c> helpers on the
+    /// imageflow-dotnet side are internal — we re-declare the tables here to
+    /// keep the Imageflow.Server project's only dependency on the public API.
+    /// </summary>
+    internal static class NamedCodecParsers
+    {
+        public static bool TryParseEncoder(string? snakeCase, out NamedEncoderName encoder)
+        {
+            switch (snakeCase)
+            {
+                case "mozjpeg_encoder":    encoder = NamedEncoderName.MozjpegEncoder; return true;
+                case "zen_jpeg_encoder":   encoder = NamedEncoderName.ZenJpegEncoder; return true;
+                case "mozjpeg_rs_encoder": encoder = NamedEncoderName.MozjpegRsEncoder; return true;
+                case "libpng_encoder":     encoder = NamedEncoderName.LibpngEncoder; return true;
+                case "lodepng_encoder":    encoder = NamedEncoderName.LodepngEncoder; return true;
+                case "pngquant_encoder":   encoder = NamedEncoderName.PngquantEncoder; return true;
+                case "zen_png_encoder":    encoder = NamedEncoderName.ZenPngEncoder; return true;
+                case "webp_encoder":       encoder = NamedEncoderName.WebpEncoder; return true;
+                case "zen_webp_encoder":   encoder = NamedEncoderName.ZenWebpEncoder; return true;
+                case "gif_encoder":        encoder = NamedEncoderName.GifEncoder; return true;
+                case "zen_gif_encoder":    encoder = NamedEncoderName.ZenGifEncoder; return true;
+                case "zen_avif_encoder":   encoder = NamedEncoderName.ZenAvifEncoder; return true;
+                case "zen_jxl_encoder":    encoder = NamedEncoderName.ZenJxlEncoder; return true;
+                case "zen_bmp_encoder":    encoder = NamedEncoderName.ZenBmpEncoder; return true;
+                default: encoder = default; return false;
+            }
+        }
+
+        public static bool TryParseDecoder(string? snakeCase, out NamedDecoderName decoder)
+        {
+            switch (snakeCase)
+            {
+                case "mozjpeg_rs_decoder":   decoder = NamedDecoderName.MozjpegRsDecoder; return true;
+                case "image_rs_jpeg_decoder":decoder = NamedDecoderName.ImageRsJpegDecoder; return true;
+                case "zen_jpeg_decoder":     decoder = NamedDecoderName.ZenJpegDecoder; return true;
+                case "libpng_decoder":       decoder = NamedDecoderName.LibpngDecoder; return true;
+                case "image_rs_png_decoder": decoder = NamedDecoderName.ImageRsPngDecoder; return true;
+                case "zen_png_decoder":      decoder = NamedDecoderName.ZenPngDecoder; return true;
+                case "gif_rs_decoder":       decoder = NamedDecoderName.GifRsDecoder; return true;
+                case "zen_gif_decoder":      decoder = NamedDecoderName.ZenGifDecoder; return true;
+                case "webp_decoder":         decoder = NamedDecoderName.WebpDecoder; return true;
+                case "zen_webp_decoder":     decoder = NamedDecoderName.ZenWebpDecoder; return true;
+                case "zen_avif_decoder":     decoder = NamedDecoderName.ZenAvifDecoder; return true;
+                case "zen_jxl_decoder":      decoder = NamedDecoderName.ZenJxlDecoder; return true;
+                case "zen_bmp_decoder":      decoder = NamedDecoderName.ZenBmpDecoder; return true;
+                default: decoder = default; return false;
+            }
+        }
+    }
+}

--- a/src/Imageflow.Server/SecurityPolicyOptions.cs
+++ b/src/Imageflow.Server/SecurityPolicyOptions.cs
@@ -1,0 +1,345 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Imageflow.Fluent;
+
+namespace Imageflow.Server
+{
+    /// <summary>
+    /// Server-layer representation of the three-layer killbits policy, plus
+    /// resource-scalar limits. Binds from <c>Imageflow:Security</c> in
+    /// <c>appsettings.json</c>, or can be constructed programmatically.
+    /// </summary>
+    /// <remarks>
+    /// Two things live together here:
+    /// <list type="bullet">
+    ///   <item><description>Trusted-policy scalars + killbits (what the
+    ///     server signs off on globally). Allow-list forms are permitted at
+    ///     this layer.</description></item>
+    ///   <item><description>Server-default risky-encode list
+    ///     (AVIF / JXL by default). Operators must opt in explicitly for
+    ///     those formats to be usable.</description></item>
+    /// </list>
+    /// Call <see cref="BuildEffectiveSecurityOptions"/> to produce a
+    /// narrowing-only <see cref="SecurityOptions"/> suitable for
+    /// <c>Build001.security</c> / <c>Execute001.security</c>. The same helper
+    /// is used by <see cref="ImageflowMiddlewareOptions.SecurityPolicyOptions"/>
+    /// at startup for trusted-context <see cref="Imageflow.Bindings.JobContext.SetPolicy"/>
+    /// validation.
+    /// </remarks>
+    public sealed class SecurityPolicyOptions
+    {
+        /// <summary>Server-default risky encode formats. See <see cref="ServerRiskyEncodeDefault"/>.</summary>
+        /// <remarks>
+        /// Replacing this list is an explicit operator choice. Prefer
+        /// leaving it alone and toggling <see cref="FormatOptions.OptInEncode"/>.
+        /// </remarks>
+        public IReadOnlyList<ImageFormat> ServerRiskyEncode { get; set; } = ServerRiskyEncodeDefault;
+
+        /// <summary>
+        /// The default set of formats the server denies encode for unless the
+        /// operator opts in. Currently {AVIF, JXL}. Exposed as a constant so
+        /// operators can see what's blocked without reading source.
+        /// </summary>
+        public static readonly IReadOnlyList<ImageFormat> ServerRiskyEncodeDefault = new[]
+        {
+            ImageFormat.Avif,
+            ImageFormat.Jxl,
+        };
+
+        // --- Scalar resource limits (forwarded verbatim to trusted policy) ---
+
+        /// <summary>Max per-frame decode dimensions. <c>null</c> leaves the native default.</summary>
+        public FrameSizeLimit? MaxDecodeSize { get; set; }
+
+        /// <summary>Max per-frame working buffer. <c>null</c> leaves the native default.</summary>
+        public FrameSizeLimit? MaxFrameSize { get; set; }
+
+        /// <summary>Max encode dimensions. <c>null</c> leaves the native default.</summary>
+        public FrameSizeLimit? MaxEncodeSize { get; set; }
+
+        /// <summary>Bytes cap on a single codec input stream. <c>null</c> leaves native default (256 MiB).</summary>
+        public ulong? MaxInputFileBytes { get; set; }
+
+        /// <summary>JSON payload size cap. <c>null</c> leaves native default (64 MiB).</summary>
+        public ulong? MaxJsonBytes { get; set; }
+
+        /// <summary>Total decoded pixels across every frame. <c>null</c> leaves native default.</summary>
+        public ulong? MaxTotalFilePixels { get; set; }
+
+        // --- Killbits ---
+
+        /// <summary>Per-format decode/encode permissions. Supports allow-list, deny-list, or table forms.</summary>
+        public FormatOptions? Formats { get; set; }
+
+        /// <summary>Per-codec permissions. Supports allow-list or deny-list forms.</summary>
+        public CodecOptions? Codecs { get; set; }
+
+        /// <summary>
+        /// Run mutual-exclusion validation. Call this at config-bind time so
+        /// misconfiguration surfaces before the server tries to talk to
+        /// imageflow.
+        /// </summary>
+        /// <exception cref="SecurityPolicyValidationException">when invariants are violated.</exception>
+        public void Validate()
+        {
+            try
+            {
+                Formats?.Validate();
+                Codecs?.Validate();
+            }
+            catch (ArgumentException ex)
+            {
+                throw new SecurityPolicyValidationException(
+                    $"Imageflow:Security — {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Compute the narrowing-only <see cref="SecurityOptions"/> the server
+        /// should apply to every job. Merges:
+        /// <list type="number">
+        ///   <item><description>Server-default risky encode list (AVIF+JXL),
+        ///     minus any operator opt-ins.</description></item>
+        ///   <item><description>Operator-supplied allow/deny/table forms.</description></item>
+        ///   <item><description>Scalar limits.</description></item>
+        /// </list>
+        /// If the operator supplied <see cref="FormatOptions.AllowEncode"/>
+        /// or mentioned one of the risky formats explicitly in
+        /// <see cref="FormatOptions.Formats"/>, the server default is
+        /// disabled for that format (the operator took control).
+        /// </summary>
+        public SecurityOptions BuildEffectiveSecurityOptions()
+        {
+            Validate();
+
+            var effective = new SecurityOptions
+            {
+                MaxDecodeSize = MaxDecodeSize,
+                MaxFrameSize = MaxFrameSize,
+                MaxEncodeSize = MaxEncodeSize,
+                MaxInputFileBytes = MaxInputFileBytes,
+                MaxJsonBytes = MaxJsonBytes,
+                MaxTotalFilePixels = MaxTotalFilePixels,
+            };
+
+            var formats = Formats ?? new FormatOptions();
+            var codecs = Codecs ?? new CodecOptions();
+
+            // ---- Merge format killbits ----
+
+            // If the operator set AllowEncode, their list wins — the server
+            // default is not applied. Similarly, if they set a table that
+            // mentions a risky format, that format is operator-controlled.
+            var operatorControlledEncode = BuildOperatorControlledEncodeSet(formats);
+            var effectiveRiskyDefault = ServerRiskyEncode
+                .Where(f => !operatorControlledEncode.Contains(f))
+                .Where(f => formats.OptInEncode == null || !formats.OptInEncode.Contains(f))
+                .ToList();
+
+            var formatKillbits = new FormatKillbits
+            {
+                AllowDecode = formats.AllowDecode?.ToList(),
+                AllowEncode = formats.AllowEncode?.ToList(),
+                Formats = formats.Formats == null
+                    ? null
+                    : new Dictionary<ImageFormat, FormatPermissions>(formats.Formats),
+            };
+
+            // DenyDecode merges operator's DenyDecode verbatim (no server default).
+            if (formats.DenyDecode != null && formats.DenyDecode.Count > 0)
+            {
+                formatKillbits.DenyDecode = formats.DenyDecode.ToList();
+            }
+
+            // DenyEncode merges operator's DenyEncode plus the effective risky default.
+            var denyEncode = new List<ImageFormat>();
+            if (effectiveRiskyDefault.Count > 0)
+            {
+                denyEncode.AddRange(effectiveRiskyDefault);
+            }
+            if (formats.DenyEncode != null)
+            {
+                foreach (var f in formats.DenyEncode)
+                {
+                    if (!denyEncode.Contains(f))
+                    {
+                        denyEncode.Add(f);
+                    }
+                }
+            }
+            if (denyEncode.Count > 0)
+            {
+                formatKillbits.DenyEncode = denyEncode;
+            }
+
+            // If the operator used table form, AllowEncode/AllowDecode/DenyEncode/DenyDecode
+            // must all be null (mutual exclusion). Push the server default into the table
+            // instead.
+            if (formats.Formats != null)
+            {
+                formatKillbits.AllowEncode = null;
+                formatKillbits.AllowDecode = null;
+                formatKillbits.DenyEncode = null;
+                formatKillbits.DenyDecode = null;
+                var mergedTable = new Dictionary<ImageFormat, FormatPermissions>();
+                foreach (var kv in formats.Formats)
+                {
+                    mergedTable[kv.Key] = kv.Value;
+                }
+                foreach (var risky in effectiveRiskyDefault)
+                {
+                    if (!mergedTable.ContainsKey(risky))
+                    {
+                        // deny encode, leave decode at the layer's existing state (true)
+                        mergedTable[risky] = new FormatPermissions(decode: true, encode: false);
+                    }
+                }
+                formatKillbits.Formats = mergedTable;
+            }
+
+            // Skip sending empty killbits — the native side treats a missing
+            // block and an empty block identically, but a missing block keeps
+            // the wire payload small and avoids confusing operators reading
+            // the startup log.
+            if (HasAnyFormatEntry(formatKillbits))
+            {
+                effective.Formats = formatKillbits;
+            }
+
+            // ---- Merge codec killbits ----
+
+            var codecKillbits = new CodecKillbits
+            {
+                AllowEncoders = codecs.AllowEncoders?.ToList(),
+                DenyEncoders = codecs.DenyEncoders?.ToList(),
+                AllowDecoders = codecs.AllowDecoders?.ToList(),
+                DenyDecoders = codecs.DenyDecoders?.ToList(),
+            };
+
+            if (HasAnyCodecEntry(codecKillbits))
+            {
+                effective.Codecs = codecKillbits;
+            }
+
+            return effective;
+        }
+
+        private static HashSet<ImageFormat> BuildOperatorControlledEncodeSet(FormatOptions formats)
+        {
+            var set = new HashSet<ImageFormat>();
+            if (formats.AllowEncode != null)
+            {
+                foreach (var f in formats.AllowEncode)
+                {
+                    set.Add(f);
+                }
+            }
+            if (formats.DenyEncode != null)
+            {
+                foreach (var f in formats.DenyEncode)
+                {
+                    set.Add(f);
+                }
+            }
+            if (formats.Formats != null)
+            {
+                foreach (var kv in formats.Formats)
+                {
+                    set.Add(kv.Key);
+                }
+            }
+            return set;
+        }
+
+        private static bool HasAnyFormatEntry(FormatKillbits k) =>
+            k.AllowDecode != null || k.DenyDecode != null ||
+            k.AllowEncode != null || k.DenyEncode != null ||
+            k.Formats != null;
+
+        private static bool HasAnyCodecEntry(CodecKillbits k) =>
+            k.AllowEncoders != null || k.DenyEncoders != null ||
+            k.AllowDecoders != null || k.DenyDecoders != null;
+    }
+
+    /// <summary>
+    /// Operator-facing shape for per-format gating. Matches the
+    /// <see cref="FormatKillbits"/> mutual-exclusion rules but adds
+    /// <see cref="OptInEncode"/> — the server-layer concept that turns on
+    /// AVIF/JXL encode without requiring the operator to spell out the full
+    /// deny-list.
+    /// </summary>
+    public sealed class FormatOptions
+    {
+        /// <summary>Opt in to formats that the server denies by default (currently AVIF and JXL).</summary>
+        public IList<ImageFormat>? OptInEncode { get; set; }
+
+        /// <summary>Allow only these formats for decode. Mutually exclusive with <see cref="DenyDecode"/> and <see cref="Formats"/>.</summary>
+        public IList<ImageFormat>? AllowDecode { get; set; }
+
+        /// <summary>Deny these formats for decode. Mutually exclusive with <see cref="AllowDecode"/>.</summary>
+        public IList<ImageFormat>? DenyDecode { get; set; }
+
+        /// <summary>Allow only these formats for encode. Mutually exclusive with <see cref="DenyEncode"/> and <see cref="Formats"/>.</summary>
+        public IList<ImageFormat>? AllowEncode { get; set; }
+
+        /// <summary>Deny these formats for encode (merged with the server's risky default). Mutually exclusive with <see cref="AllowEncode"/>.</summary>
+        public IList<ImageFormat>? DenyEncode { get; set; }
+
+        /// <summary>Per-format table form. Mutually exclusive with any of the list forms.</summary>
+        public IDictionary<ImageFormat, FormatPermissions>? Formats { get; set; }
+
+        internal void Validate()
+        {
+            if (AllowDecode != null && DenyDecode != null)
+            {
+                throw new ArgumentException(
+                    "Formats: pick allow or deny for decode, not both", nameof(AllowDecode));
+            }
+            if (AllowEncode != null && DenyEncode != null)
+            {
+                throw new ArgumentException(
+                    "Formats: pick allow or deny for encode, not both", nameof(AllowEncode));
+            }
+            var hasList = AllowDecode != null || DenyDecode != null ||
+                          AllowEncode != null || DenyEncode != null;
+            if (hasList && Formats != null)
+            {
+                throw new ArgumentException(
+                    "Formats: pick a single form (allow/deny lists OR table), not a mix",
+                    nameof(Formats));
+            }
+        }
+    }
+
+    /// <summary>Operator-facing shape for per-codec gating.</summary>
+    public sealed class CodecOptions
+    {
+        public IList<NamedEncoderName>? AllowEncoders { get; set; }
+        public IList<NamedEncoderName>? DenyEncoders { get; set; }
+        public IList<NamedDecoderName>? AllowDecoders { get; set; }
+        public IList<NamedDecoderName>? DenyDecoders { get; set; }
+
+        internal void Validate()
+        {
+            if (AllowEncoders != null && DenyEncoders != null)
+            {
+                throw new ArgumentException(
+                    "Codecs: pick allow or deny for encoders, not both", nameof(AllowEncoders));
+            }
+            if (AllowDecoders != null && DenyDecoders != null)
+            {
+                throw new ArgumentException(
+                    "Codecs: pick allow or deny for decoders, not both", nameof(AllowDecoders));
+            }
+        }
+    }
+
+    /// <summary>Thrown at startup when <see cref="SecurityPolicyOptions"/> is internally inconsistent.</summary>
+    public sealed class SecurityPolicyValidationException : Exception
+    {
+        public SecurityPolicyValidationException(string message) : base(message) { }
+        public SecurityPolicyValidationException(string message, Exception inner) : base(message, inner) { }
+    }
+}

--- a/src/Imageflow.Server/SecurityPolicyOptions.cs
+++ b/src/Imageflow.Server/SecurityPolicyOptions.cs
@@ -129,9 +129,12 @@ namespace Imageflow.Server
 
             // ---- Merge format killbits ----
 
-            // If the operator set AllowEncode, their list wins — the server
-            // default is not applied. Similarly, if they set a table that
-            // mentions a risky format, that format is operator-controlled.
+            // Figure out whether the operator took explicit control over
+            // encode gating. In that case the server default does not apply
+            // and mutual-exclusion forbids us from layering a deny list on
+            // top of an allow list.
+            var usesAllowEncode = formats.AllowEncode != null;
+            var usesTableForm = formats.Formats != null;
             var operatorControlledEncode = BuildOperatorControlledEncodeSet(formats);
             var effectiveRiskyDefault = ServerRiskyEncode
                 .Where(f => !operatorControlledEncode.Contains(f))
@@ -153,38 +156,17 @@ namespace Imageflow.Server
                 formatKillbits.DenyDecode = formats.DenyDecode.ToList();
             }
 
-            // DenyEncode merges operator's DenyEncode plus the effective risky default.
-            var denyEncode = new List<ImageFormat>();
-            if (effectiveRiskyDefault.Count > 0)
+            if (usesTableForm)
             {
-                denyEncode.AddRange(effectiveRiskyDefault);
-            }
-            if (formats.DenyEncode != null)
-            {
-                foreach (var f in formats.DenyEncode)
-                {
-                    if (!denyEncode.Contains(f))
-                    {
-                        denyEncode.Add(f);
-                    }
-                }
-            }
-            if (denyEncode.Count > 0)
-            {
-                formatKillbits.DenyEncode = denyEncode;
-            }
-
-            // If the operator used table form, AllowEncode/AllowDecode/DenyEncode/DenyDecode
-            // must all be null (mutual exclusion). Push the server default into the table
-            // instead.
-            if (formats.Formats != null)
-            {
+                // Table form: allow/deny lists are forbidden (mutual exclusion
+                // on the native side). Push unmentioned risky defaults into
+                // the table as explicit encode-false entries.
                 formatKillbits.AllowEncode = null;
                 formatKillbits.AllowDecode = null;
                 formatKillbits.DenyEncode = null;
                 formatKillbits.DenyDecode = null;
                 var mergedTable = new Dictionary<ImageFormat, FormatPermissions>();
-                foreach (var kv in formats.Formats)
+                foreach (var kv in formats.Formats!)
                 {
                     mergedTable[kv.Key] = kv.Value;
                 }
@@ -192,11 +174,40 @@ namespace Imageflow.Server
                 {
                     if (!mergedTable.ContainsKey(risky))
                     {
-                        // deny encode, leave decode at the layer's existing state (true)
                         mergedTable[risky] = new FormatPermissions(decode: true, encode: false);
                     }
                 }
                 formatKillbits.Formats = mergedTable;
+            }
+            else if (usesAllowEncode)
+            {
+                // Allow-list form: we cannot add a deny list (mutual exclusion).
+                // The operator took control; server default does not apply.
+                formatKillbits.DenyEncode = null;
+            }
+            else
+            {
+                // Deny-list form (default path): merge operator's DenyEncode
+                // with the effective risky default.
+                var denyEncode = new List<ImageFormat>();
+                if (effectiveRiskyDefault.Count > 0)
+                {
+                    denyEncode.AddRange(effectiveRiskyDefault);
+                }
+                if (formats.DenyEncode != null)
+                {
+                    foreach (var f in formats.DenyEncode)
+                    {
+                        if (!denyEncode.Contains(f))
+                        {
+                            denyEncode.Add(f);
+                        }
+                    }
+                }
+                if (denyEncode.Count > 0)
+                {
+                    formatKillbits.DenyEncode = denyEncode;
+                }
             }
 
             // Skip sending empty killbits — the native side treats a missing

--- a/src/Imageflow.Server/SecurityPolicyValidator.cs
+++ b/src/Imageflow.Server/SecurityPolicyValidator.cs
@@ -1,0 +1,134 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Text;
+using Imageflow.Bindings;
+using Imageflow.Fluent;
+using Microsoft.Extensions.Logging;
+
+namespace Imageflow.Server
+{
+    /// <summary>
+    /// Applies a <see cref="SecurityPolicyOptions"/> to a one-shot
+    /// <see cref="JobContext"/> at startup, captures the resulting
+    /// <see cref="NetSupportResponse"/>, and exposes it as a readonly
+    /// snapshot for the rest of the server process.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// We don't keep the <see cref="JobContext"/> alive after startup —
+    /// <see cref="Imageflow.Fluent.ImageJob"/> creates a fresh context
+    /// per job, so there's no persistent context to hold a trusted policy
+    /// on. Instead, the server expresses the same policy as a narrowing
+    /// per-job security block on every request.
+    /// </para>
+    /// <para>
+    /// The one-shot <c>SetPolicy</c> call at startup serves two purposes:
+    /// </para>
+    /// <list type="number">
+    ///   <item><description>It surfaces bad configuration loudly (the
+    ///     native side validates mutual exclusion and reports
+    ///     <c>invalid_policy</c>), failing fast rather than silently
+    ///     degrading at first request.</description></item>
+    ///   <item><description>It captures the <see cref="NetSupportResponse"/>
+    ///     grid operators need in order to diagnose "why not WebP?". The
+    ///     cached snapshot is published through <see cref="EffectiveNetSupport"/>
+    ///     and summarized on a single startup log line tagged
+    ///     <c>killbits-policy</c>.</description></item>
+    /// </list>
+    /// </remarks>
+    public sealed class SecurityPolicyValidator
+    {
+        private NetSupportResponse? _netSupport;
+        private SecurityOptions? _effective;
+
+        /// <summary>
+        /// Narrowing-only <see cref="SecurityOptions"/> computed from the
+        /// operator's <see cref="SecurityPolicyOptions"/>. Safe to attach to
+        /// every job via <c>FinishJobBuilder.SetSecurityOptions</c>.
+        /// <c>null</c> until <see cref="Apply"/> has run.
+        /// </summary>
+        public SecurityOptions? EffectiveJobSecurity => _effective;
+
+        /// <summary>
+        /// Grid captured at startup after the trusted policy was installed
+        /// on a one-shot context. <c>null</c> until <see cref="Apply"/> has
+        /// run.
+        /// </summary>
+        public NetSupportResponse? EffectiveNetSupport => _netSupport;
+
+        /// <summary>
+        /// Validate the policy, send it to imageflow on a scratch context,
+        /// and record the resulting <see cref="NetSupportResponse"/>.
+        /// Logs a single structured line (search log for
+        /// <c>killbits-policy</c>) summarizing the effective grid.
+        /// </summary>
+        /// <exception cref="SecurityPolicyValidationException">
+        ///   When the native side rejects the policy (malformed, missing
+        ///   endpoint, or unknown format/codec name).
+        /// </exception>
+        public void Apply(SecurityPolicyOptions options, ILogger? logger = null)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            options.Validate();
+            _effective = options.BuildEffectiveSecurityOptions();
+
+            // Spin up a one-shot context solely to validate the policy and
+            // grab the grid. Any failure here should take down startup.
+            try
+            {
+                using var ctx = new JobContext();
+                var response = ctx.SetPolicy(_effective);
+                _netSupport = response.NetSupport;
+            }
+            catch (ImageflowException ex)
+            {
+                throw new SecurityPolicyValidationException(
+                    "Imageflow rejected the killbits policy at startup. "
+                    + "Check Imageflow:Security in configuration. Underlying error: "
+                    + ex.Message, ex);
+            }
+
+            LogSummary(options, logger);
+        }
+
+        private void LogSummary(SecurityPolicyOptions options, ILogger? logger)
+        {
+            if (logger == null || _netSupport == null)
+            {
+                return;
+            }
+
+            var allowedFormatsDecode = new StringBuilder();
+            var allowedFormatsEncode = new StringBuilder();
+            foreach (var kv in _netSupport.Formats)
+            {
+                if (kv.Value.Decode)
+                {
+                    if (allowedFormatsDecode.Length > 0) allowedFormatsDecode.Append(',');
+                    allowedFormatsDecode.Append(kv.Key);
+                }
+                if (kv.Value.Encode)
+                {
+                    if (allowedFormatsEncode.Length > 0) allowedFormatsEncode.Append(',');
+                    allowedFormatsEncode.Append(kv.Key);
+                }
+            }
+
+            var riskyStr = options.ServerRiskyEncode.Count == 0
+                ? "(none)"
+                : string.Join(",", options.ServerRiskyEncode.Select(f => f.ToString().ToLowerInvariant()));
+
+            logger.LogInformation(
+                "killbits-policy server_risky_encode=[{Risky}] decode_allowed=[{Decode}] encode_allowed=[{Encode}] trusted_policy_set={Trusted}",
+                riskyStr,
+                allowedFormatsDecode.ToString(),
+                allowedFormatsEncode.ToString(),
+                _netSupport.TrustedPolicySet);
+        }
+    }
+}

--- a/src/Imageflow.Server/packages.lock.json
+++ b/src/Imageflow.Server/packages.lock.json
@@ -2,14 +2,19 @@
   "version": 1,
   "dependencies": {
     "net6.0": {
-      "Imageflow.AllPlatforms": {
+      "Imageflow.NativeRuntime.All": {
         "type": "Direct",
-        "requested": "[0.15.1, )",
-        "resolved": "0.15.1",
-        "contentHash": "Oiaeaz+0ZJip+n+0LD05boBiHKHBWVO79Wnitms3GYzjm9kxYqcSnPtQ9QRdUrwlP39dq8vurYtL4dAZaRmliQ==",
+        "requested": "[2.3.1-rc01, 4.0.0)",
+        "resolved": "2.3.1-rc01",
+        "contentHash": "JfHaGqSChFOZcyXH8cUXMF/fm1Bn32BBjgkLY+OSCWpVlL82lrsYr/Ue5Llf74q+tEEIIO7U7Xrw1NbugGKB8w==",
         "dependencies": {
-          "Imageflow.NativeRuntime.All": "2.3.1-rc01",
-          "Imageflow.Net": "0.15.1"
+          "Imageflow.NativeRuntime.linux-arm64": "2.3.1-rc01",
+          "Imageflow.NativeRuntime.linux-x64": "2.3.1-rc01",
+          "Imageflow.NativeRuntime.osx-arm64": "2.3.1-rc01",
+          "Imageflow.NativeRuntime.osx-x86_64": "2.3.1-rc01",
+          "Imageflow.NativeRuntime.win-arm64": "2.3.1-rc01",
+          "Imageflow.NativeRuntime.win-x86": "2.3.1-rc01",
+          "Imageflow.NativeRuntime.win-x86_64": "2.3.1-rc01"
         }
       },
       "Microsoft.CodeAnalysis.PublicApiAnalyzers": {
@@ -36,20 +41,6 @@
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Text.Encodings.Web": "8.0.0"
-        }
-      },
-      "Imageflow.NativeRuntime.All": {
-        "type": "Transitive",
-        "resolved": "2.3.1-rc01",
-        "contentHash": "JfHaGqSChFOZcyXH8cUXMF/fm1Bn32BBjgkLY+OSCWpVlL82lrsYr/Ue5Llf74q+tEEIIO7U7Xrw1NbugGKB8w==",
-        "dependencies": {
-          "Imageflow.NativeRuntime.linux-arm64": "2.3.1-rc01",
-          "Imageflow.NativeRuntime.linux-x64": "2.3.1-rc01",
-          "Imageflow.NativeRuntime.osx-arm64": "2.3.1-rc01",
-          "Imageflow.NativeRuntime.osx-x86_64": "2.3.1-rc01",
-          "Imageflow.NativeRuntime.win-arm64": "2.3.1-rc01",
-          "Imageflow.NativeRuntime.win-x86": "2.3.1-rc01",
-          "Imageflow.NativeRuntime.win-x86_64": "2.3.1-rc01"
         }
       },
       "Imageflow.NativeRuntime.linux-arm64": {
@@ -86,15 +77,6 @@
         "type": "Transitive",
         "resolved": "2.3.1-rc01",
         "contentHash": "rkUNn0BVgwobB05obVXEtrX4CvOpcIJ2A8InvO2vPJkRYgqjr5+GIKT0ItgCd90K30ozkWIyvG70KxDs/OL/dw=="
-      },
-      "Imageflow.Net": {
-        "type": "Transitive",
-        "resolved": "0.15.1",
-        "contentHash": "A+gdXZ4gxl++sjGEQIEh1r4CiRMBM5KD2Y0/993weNSPbfkUu+jrP4nGZ/nAOvjM/eRXFYP/gNnazaxDA2QeeQ==",
-        "dependencies": {
-          "Microsoft.IO.RecyclableMemoryStream": "[3.0.1, 4.0.0)",
-          "System.Text.Json": "8.0.6"
-        }
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -175,6 +157,13 @@
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
+      "imageflow.net": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.IO.RecyclableMemoryStream": "[3.*, 4.0.0)",
+          "System.Text.Json": "[8.0.6, )"
+        }
+      },
       "imazen.common": {
         "type": "Project",
         "dependencies": {
@@ -183,14 +172,19 @@
       }
     },
     "net8.0": {
-      "Imageflow.AllPlatforms": {
+      "Imageflow.NativeRuntime.All": {
         "type": "Direct",
-        "requested": "[0.15.1, )",
-        "resolved": "0.15.1",
-        "contentHash": "Oiaeaz+0ZJip+n+0LD05boBiHKHBWVO79Wnitms3GYzjm9kxYqcSnPtQ9QRdUrwlP39dq8vurYtL4dAZaRmliQ==",
+        "requested": "[2.3.1-rc01, 4.0.0)",
+        "resolved": "2.3.1-rc01",
+        "contentHash": "JfHaGqSChFOZcyXH8cUXMF/fm1Bn32BBjgkLY+OSCWpVlL82lrsYr/Ue5Llf74q+tEEIIO7U7Xrw1NbugGKB8w==",
         "dependencies": {
-          "Imageflow.NativeRuntime.All": "2.3.1-rc01",
-          "Imageflow.Net": "0.15.1"
+          "Imageflow.NativeRuntime.linux-arm64": "2.3.1-rc01",
+          "Imageflow.NativeRuntime.linux-x64": "2.3.1-rc01",
+          "Imageflow.NativeRuntime.osx-arm64": "2.3.1-rc01",
+          "Imageflow.NativeRuntime.osx-x86_64": "2.3.1-rc01",
+          "Imageflow.NativeRuntime.win-arm64": "2.3.1-rc01",
+          "Imageflow.NativeRuntime.win-x86": "2.3.1-rc01",
+          "Imageflow.NativeRuntime.win-x86_64": "2.3.1-rc01"
         }
       },
       "Microsoft.CodeAnalysis.PublicApiAnalyzers": {
@@ -214,20 +208,6 @@
         "requested": "[8.0.6, )",
         "resolved": "8.0.6",
         "contentHash": "BvSpVBsVN9b+Y+wONbvJOHd1HjXQf33+XiC28ZMOwRsYb42mz3Q8YHnpTSwpwJLqYCMqM+0UUVC3V+pi25XfkQ=="
-      },
-      "Imageflow.NativeRuntime.All": {
-        "type": "Transitive",
-        "resolved": "2.3.1-rc01",
-        "contentHash": "JfHaGqSChFOZcyXH8cUXMF/fm1Bn32BBjgkLY+OSCWpVlL82lrsYr/Ue5Llf74q+tEEIIO7U7Xrw1NbugGKB8w==",
-        "dependencies": {
-          "Imageflow.NativeRuntime.linux-arm64": "2.3.1-rc01",
-          "Imageflow.NativeRuntime.linux-x64": "2.3.1-rc01",
-          "Imageflow.NativeRuntime.osx-arm64": "2.3.1-rc01",
-          "Imageflow.NativeRuntime.osx-x86_64": "2.3.1-rc01",
-          "Imageflow.NativeRuntime.win-arm64": "2.3.1-rc01",
-          "Imageflow.NativeRuntime.win-x86": "2.3.1-rc01",
-          "Imageflow.NativeRuntime.win-x86_64": "2.3.1-rc01"
-        }
       },
       "Imageflow.NativeRuntime.linux-arm64": {
         "type": "Transitive",
@@ -263,14 +243,6 @@
         "type": "Transitive",
         "resolved": "2.3.1-rc01",
         "contentHash": "rkUNn0BVgwobB05obVXEtrX4CvOpcIJ2A8InvO2vPJkRYgqjr5+GIKT0ItgCd90K30ozkWIyvG70KxDs/OL/dw=="
-      },
-      "Imageflow.Net": {
-        "type": "Transitive",
-        "resolved": "0.15.1",
-        "contentHash": "A+gdXZ4gxl++sjGEQIEh1r4CiRMBM5KD2Y0/993weNSPbfkUu+jrP4nGZ/nAOvjM/eRXFYP/gNnazaxDA2QeeQ==",
-        "dependencies": {
-          "Microsoft.IO.RecyclableMemoryStream": "[3.0.1, 4.0.0)"
-        }
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -342,6 +314,12 @@
         "type": "Transitive",
         "resolved": "4.5.1",
         "contentHash": "Zh8t8oqolRaFa9vmOZfdQm/qKejdqz0J9kr7o2Fu0vPeoH3BL1EOXipKWwkWtLT1JPzjByrF19fGuFlNbmPpiw=="
+      },
+      "imageflow.net": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.IO.RecyclableMemoryStream": "[3.*, 4.0.0)"
+        }
       },
       "imazen.common": {
         "type": "Project",

--- a/tests/Imageflow.Server.Tests/Imageflow.Server.Tests.csproj
+++ b/tests/Imageflow.Server.Tests/Imageflow.Server.Tests.csproj
@@ -9,10 +9,13 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.5" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="PublicApiGenerator" Version="11.4.6" />
         <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Imageflow.Server.Tests/KillbitsIntegrationTest.cs
+++ b/tests/Imageflow.Server.Tests/KillbitsIntegrationTest.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Imageflow.Fluent;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Imageflow.Server.Tests
+{
+    /// <summary>
+    /// Integration tests for the three-layer killbits surface. These spin up
+    /// the full middleware and run actual image jobs.
+    /// </summary>
+    /// <remarks>
+    /// These tests require a native runtime that implements
+    /// <c>v1/context/set_policy</c> + <c>v1/context/get_net_support</c>
+    /// (imageflow PR #720 and later). On older builds the server's startup
+    /// call to <see cref="Imageflow.Bindings.JobContext.SetPolicy"/> throws
+    /// with <c>InvalidMessageEndpoint</c>, so these tests are gated behind
+    /// the environment variable
+    /// <c>IMAGEFLOW_TESTS_KILLBITS_NATIVE=1</c>. The caller (CI workflow /
+    /// justfile) decides when to set it — the test body never silently
+    /// skips itself (per imazen global test policy).
+    /// </remarks>
+    [Trait("Category", "Killbits")]
+    [Trait("RequiresNativeCapability", "killbits")]
+    public class KillbitsIntegrationTest
+    {
+        private static bool NativeAvailable()
+        {
+            var flag = Environment.GetEnvironmentVariable("IMAGEFLOW_TESTS_KILLBITS_NATIVE");
+            return flag == "1" || string.Equals(flag, "true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        [SkippableFact]
+        public async Task Default_AvifEncodeRequest_Returns422()
+        {
+            SkipIfNoKillbitsNative();
+            using var contentRoot = new TempContentRoot()
+                .AddResource("images/fire.jpg", "TestFiles.fire-umbrella-small.jpg");
+
+            var hostBuilder = new HostBuilder().ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.Configure(app =>
+                {
+                    app.UseImageflow(new ImageflowMiddlewareOptions()
+                        .SetMapWebRoot(false)
+                        .MapPath("/", Path.Combine(contentRoot.PhysicalPath, "images"))
+                        .SetSecurityPolicyOptions(new SecurityPolicyOptions())); // server defaults → AVIF denied
+                });
+            });
+
+            using var host = await hostBuilder.StartAsync();
+            using var client = host.GetTestClient();
+
+            using var resp = await client.GetAsync("/fire.jpg?format=avif");
+            Assert.Equal((HttpStatusCode)422, resp.StatusCode);
+            var body = await resp.Content.ReadAsStringAsync();
+            using var parsed = JsonDocument.Parse(body);
+            Assert.True(parsed.RootElement.TryGetProperty("error", out var err));
+            Assert.Contains("not_available", err.GetString());
+        }
+
+        [SkippableFact]
+        public async Task OptInAvif_AvifEncodeRequest_Returns200()
+        {
+            SkipIfNoKillbitsNative();
+            using var contentRoot = new TempContentRoot()
+                .AddResource("images/fire.jpg", "TestFiles.fire-umbrella-small.jpg");
+
+            var hostBuilder = new HostBuilder().ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.Configure(app =>
+                {
+                    app.UseImageflow(new ImageflowMiddlewareOptions()
+                        .SetMapWebRoot(false)
+                        .MapPath("/", Path.Combine(contentRoot.PhysicalPath, "images"))
+                        .SetSecurityPolicyOptions(new SecurityPolicyOptions
+                        {
+                            Formats = new FormatOptions
+                            {
+                                OptInEncode = new List<ImageFormat> { ImageFormat.Avif },
+                            },
+                        }));
+                });
+            });
+
+            using var host = await hostBuilder.StartAsync();
+            using var client = host.GetTestClient();
+
+            using var resp = await client.GetAsync("/fire.jpg?format=avif");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+
+        [SkippableFact]
+        public async Task InvalidPolicy_StartupFailsLoudly()
+        {
+            SkipIfNoKillbitsNative();
+            using var contentRoot = new TempContentRoot()
+                .AddResource("images/fire.jpg", "TestFiles.fire-umbrella-small.jpg");
+
+            // Mutually-exclusive allow + deny should fail at validation time
+            // (Validate() is called before the native SetPolicy round-trip, so
+            // this test works even when the native lacks killbits endpoints —
+            // but we still gate it behind the capability flag because a fully
+            // configured server path makes the test meaningful for regression).
+            var hostBuilder = new HostBuilder().ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.Configure(app =>
+                {
+                    app.UseImageflow(new ImageflowMiddlewareOptions()
+                        .SetMapWebRoot(false)
+                        .MapPath("/", Path.Combine(contentRoot.PhysicalPath, "images"))
+                        .SetSecurityPolicyOptions(new SecurityPolicyOptions
+                        {
+                            Formats = new FormatOptions
+                            {
+                                AllowEncode = new List<ImageFormat> { ImageFormat.Jpeg },
+                                DenyEncode = new List<ImageFormat> { ImageFormat.Webp },
+                            },
+                        }));
+                });
+            });
+
+            await Assert.ThrowsAsync<SecurityPolicyValidationException>(async () =>
+            {
+                using var host = await hostBuilder.StartAsync();
+                // The exception is raised inside the middleware constructor,
+                // which only runs on the first request. Issue a request to
+                // surface it.
+                using var client = host.GetTestClient();
+                using var _ = await client.GetAsync("/fire.jpg");
+            });
+        }
+
+        private static void SkipIfNoKillbitsNative()
+        {
+            Skip.IfNot(NativeAvailable(),
+                "IMAGEFLOW_TESTS_KILLBITS_NATIVE is not set; native runtime "
+                + "does not implement v1/context/set_policy. Enable this flag "
+                + "in CI once an imageflow runtime with PR #720 ships.");
+        }
+    }
+}

--- a/tests/Imageflow.Server.Tests/SecurityPolicyConfigurationBinderTests.cs
+++ b/tests/Imageflow.Server.Tests/SecurityPolicyConfigurationBinderTests.cs
@@ -1,0 +1,168 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Imageflow.Fluent;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Imageflow.Server.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="SecurityPolicyConfigurationBinder"/>.
+    /// Verifies JSON binding produces equivalent <see cref="SecurityPolicyOptions"/>
+    /// and that malformed input surfaces as
+    /// <see cref="SecurityPolicyValidationException"/>.
+    /// </summary>
+    public class SecurityPolicyConfigurationBinderTests
+    {
+        private static IConfiguration BuildConfig(string json)
+        {
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            return new ConfigurationBuilder().AddJsonStream(stream).Build();
+        }
+
+        [Fact]
+        public void MissingSection_ReturnsNull()
+        {
+            var config = BuildConfig("{\"Something\": true}");
+            var section = config.GetSection(SecurityPolicyConfigurationBinder.DefaultSectionPath);
+            var bound = SecurityPolicyConfigurationBinder.Bind(section);
+            Assert.Null(bound);
+        }
+
+        [Fact]
+        public void FormatsOptInEncode_Binds()
+        {
+            const string json = "{"
+                + "\"Imageflow\":{\"Security\":{"
+                + "  \"Formats\":{ \"OptInEncode\": [ \"avif\" ] }"
+                + "}}}";
+            var config = BuildConfig(json);
+            var section = config.GetSection(SecurityPolicyConfigurationBinder.DefaultSectionPath);
+            var bound = SecurityPolicyConfigurationBinder.Bind(section);
+            Assert.NotNull(bound);
+            Assert.NotNull(bound!.Formats);
+            Assert.NotNull(bound.Formats!.OptInEncode);
+            Assert.Single(bound.Formats.OptInEncode!);
+            Assert.Equal(ImageFormat.Avif, bound.Formats.OptInEncode![0]);
+        }
+
+        [Fact]
+        public void DenyLists_Bind()
+        {
+            const string json = "{"
+                + "\"Imageflow\":{\"Security\":{"
+                + "  \"Formats\":{"
+                + "    \"DenyEncode\": [ \"webp\" ],"
+                + "    \"DenyDecode\": [ \"heic\" ]"
+                + "  }"
+                + "}}}";
+            var config = BuildConfig(json);
+            var section = config.GetSection(SecurityPolicyConfigurationBinder.DefaultSectionPath);
+            var bound = SecurityPolicyConfigurationBinder.Bind(section);
+            Assert.NotNull(bound);
+            Assert.Contains(ImageFormat.Webp, bound!.Formats!.DenyEncode!);
+            Assert.Contains(ImageFormat.Heic, bound.Formats.DenyDecode!);
+        }
+
+        [Fact]
+        public void UnknownFormat_RaisesValidationException()
+        {
+            const string json = "{"
+                + "\"Imageflow\":{\"Security\":{"
+                + "  \"Formats\":{ \"DenyEncode\": [ \"nonexistent_fmt\" ] }"
+                + "}}}";
+            var config = BuildConfig(json);
+            var section = config.GetSection(SecurityPolicyConfigurationBinder.DefaultSectionPath);
+            var ex = Assert.Throws<SecurityPolicyValidationException>(
+                () => SecurityPolicyConfigurationBinder.Bind(section));
+            Assert.Contains("nonexistent_fmt", ex.Message);
+        }
+
+        [Fact]
+        public void CodecDenyEncoders_Bind()
+        {
+            const string json = "{"
+                + "\"Imageflow\":{\"Security\":{"
+                + "  \"Codecs\":{ \"DenyEncoders\": [ \"mozjpeg_encoder\" ] }"
+                + "}}}";
+            var config = BuildConfig(json);
+            var section = config.GetSection(SecurityPolicyConfigurationBinder.DefaultSectionPath);
+            var bound = SecurityPolicyConfigurationBinder.Bind(section);
+            Assert.NotNull(bound);
+            Assert.Contains(NamedEncoderName.MozjpegEncoder, bound!.Codecs!.DenyEncoders!);
+        }
+
+        [Fact]
+        public void UnknownCodec_RaisesValidationException()
+        {
+            const string json = "{"
+                + "\"Imageflow\":{\"Security\":{"
+                + "  \"Codecs\":{ \"DenyEncoders\": [ \"bogus_codec\" ] }"
+                + "}}}";
+            var config = BuildConfig(json);
+            var section = config.GetSection(SecurityPolicyConfigurationBinder.DefaultSectionPath);
+            Assert.Throws<SecurityPolicyValidationException>(
+                () => SecurityPolicyConfigurationBinder.Bind(section));
+        }
+
+        [Fact]
+        public void ScalarLimits_Bind()
+        {
+            const string json = "{"
+                + "\"Imageflow\":{\"Security\":{"
+                + "  \"MaxDecodeSize\":{ \"W\": 8000, \"H\": 8000, \"Megapixels\": 50 },"
+                + "  \"MaxInputFileBytes\": 268435456,"
+                + "  \"MaxJsonBytes\": 67108864"
+                + "}}}";
+            var config = BuildConfig(json);
+            var section = config.GetSection(SecurityPolicyConfigurationBinder.DefaultSectionPath);
+            var bound = SecurityPolicyConfigurationBinder.Bind(section);
+            Assert.NotNull(bound);
+            Assert.NotNull(bound!.MaxDecodeSize);
+            Assert.Equal(8000u, bound.MaxDecodeSize!.Value.MaxWidth);
+            Assert.Equal(8000u, bound.MaxDecodeSize.Value.MaxHeight);
+            Assert.Equal(50f, bound.MaxDecodeSize.Value.MaxMegapixels);
+            Assert.Equal(268435456UL, bound.MaxInputFileBytes);
+            Assert.Equal(67108864UL, bound.MaxJsonBytes);
+        }
+
+        [Fact]
+        public void AllowAndDenyTogether_RaisesValidationException()
+        {
+            const string json = "{"
+                + "\"Imageflow\":{\"Security\":{"
+                + "  \"Formats\":{"
+                + "    \"AllowEncode\": [ \"jpeg\" ],"
+                + "    \"DenyEncode\":  [ \"webp\" ]"
+                + "  }"
+                + "}}}";
+            var config = BuildConfig(json);
+            var section = config.GetSection(SecurityPolicyConfigurationBinder.DefaultSectionPath);
+            Assert.Throws<SecurityPolicyValidationException>(
+                () => SecurityPolicyConfigurationBinder.Bind(section));
+        }
+
+        [Fact]
+        public void TableForm_Binds()
+        {
+            const string json = "{"
+                + "\"Imageflow\":{\"Security\":{"
+                + "  \"Formats\":{"
+                + "    \"Formats\":{"
+                + "      \"avif\":{ \"Decode\": true, \"Encode\": true },"
+                + "      \"jxl\": { \"Decode\": true, \"Encode\": false }"
+                + "    }"
+                + "  }"
+                + "}}}";
+            var config = BuildConfig(json);
+            var section = config.GetSection(SecurityPolicyConfigurationBinder.DefaultSectionPath);
+            var bound = SecurityPolicyConfigurationBinder.Bind(section);
+            Assert.NotNull(bound);
+            Assert.NotNull(bound!.Formats!.Formats);
+            Assert.True(bound.Formats.Formats!.ContainsKey(ImageFormat.Avif));
+            Assert.True(bound.Formats.Formats[ImageFormat.Avif].Encode);
+            Assert.False(bound.Formats.Formats[ImageFormat.Jxl].Encode);
+        }
+    }
+}

--- a/tests/Imageflow.Server.Tests/SecurityPolicyOptionsTests.cs
+++ b/tests/Imageflow.Server.Tests/SecurityPolicyOptionsTests.cs
@@ -1,0 +1,235 @@
+using System.Collections.Generic;
+using System.Linq;
+using Imageflow.Fluent;
+using Xunit;
+
+namespace Imageflow.Server.Tests
+{
+    /// <summary>
+    /// Unit tests for the three-layer killbits surface on
+    /// <see cref="SecurityPolicyOptions"/>. Verifies:
+    /// - mutual-exclusion validation
+    /// - AVIF/JXL opt-in translation
+    /// - allow-list / deny-list / table form merges
+    /// - explicit operator control disables server default per format
+    /// </summary>
+    public class SecurityPolicyOptionsTests
+    {
+        [Fact]
+        public void Default_DeniesAvifAndJxlEncode()
+        {
+            var policy = new SecurityPolicyOptions();
+            var effective = policy.BuildEffectiveSecurityOptions();
+            Assert.NotNull(effective.Formats);
+            Assert.NotNull(effective.Formats!.DenyEncode);
+            Assert.Contains(ImageFormat.Avif, effective.Formats.DenyEncode!);
+            Assert.Contains(ImageFormat.Jxl, effective.Formats.DenyEncode!);
+            Assert.Null(effective.Formats.AllowEncode);
+            Assert.Null(effective.Formats.AllowDecode);
+            Assert.Null(effective.Formats.Formats);
+        }
+
+        [Fact]
+        public void OptInAvif_StillDeniesJxl()
+        {
+            var policy = new SecurityPolicyOptions
+            {
+                Formats = new FormatOptions
+                {
+                    OptInEncode = new List<ImageFormat> { ImageFormat.Avif },
+                },
+            };
+            var effective = policy.BuildEffectiveSecurityOptions();
+            Assert.NotNull(effective.Formats!.DenyEncode);
+            Assert.DoesNotContain(ImageFormat.Avif, effective.Formats.DenyEncode!);
+            Assert.Contains(ImageFormat.Jxl, effective.Formats.DenyEncode!);
+        }
+
+        [Fact]
+        public void OptInBoth_DeniesNeither()
+        {
+            var policy = new SecurityPolicyOptions
+            {
+                Formats = new FormatOptions
+                {
+                    OptInEncode = new List<ImageFormat> { ImageFormat.Avif, ImageFormat.Jxl },
+                },
+            };
+            var effective = policy.BuildEffectiveSecurityOptions();
+            // Nothing to deny beyond the opt-ins; no killbits required.
+            Assert.True(effective.Formats == null
+                || effective.Formats.DenyEncode == null
+                || (!effective.Formats.DenyEncode!.Contains(ImageFormat.Avif)
+                    && !effective.Formats.DenyEncode!.Contains(ImageFormat.Jxl)));
+        }
+
+        [Fact]
+        public void AllowEncodeList_DisablesServerDefaultForAvifAndJxl()
+        {
+            var policy = new SecurityPolicyOptions
+            {
+                Formats = new FormatOptions
+                {
+                    AllowEncode = new List<ImageFormat> { ImageFormat.Jpeg, ImageFormat.Png },
+                },
+            };
+            var effective = policy.BuildEffectiveSecurityOptions();
+            Assert.NotNull(effective.Formats);
+            Assert.NotNull(effective.Formats!.AllowEncode);
+            Assert.Equal(2, effective.Formats.AllowEncode!.Count);
+            Assert.Contains(ImageFormat.Jpeg, effective.Formats.AllowEncode);
+            Assert.Contains(ImageFormat.Png, effective.Formats.AllowEncode);
+            // Allow-list and deny-list are mutually exclusive — no server-default deny list.
+            Assert.Null(effective.Formats.DenyEncode);
+        }
+
+        [Fact]
+        public void TableFormMentionsAvif_DisablesServerDefaultForAvif()
+        {
+            // Explicit operator decision: AVIF encode allowed via table.
+            var policy = new SecurityPolicyOptions
+            {
+                Formats = new FormatOptions
+                {
+                    Formats = new Dictionary<ImageFormat, FormatPermissions>
+                    {
+                        { ImageFormat.Avif, new FormatPermissions(decode: true, encode: true) },
+                    },
+                },
+            };
+            var effective = policy.BuildEffectiveSecurityOptions();
+            Assert.NotNull(effective.Formats);
+            Assert.NotNull(effective.Formats!.Formats);
+            Assert.True(effective.Formats.Formats![ImageFormat.Avif].Encode);
+            // JXL wasn't mentioned → server default still applies, but since
+            // we're in table form, the default is injected as a table entry.
+            Assert.True(effective.Formats.Formats.ContainsKey(ImageFormat.Jxl));
+            Assert.False(effective.Formats.Formats[ImageFormat.Jxl].Encode);
+            Assert.Null(effective.Formats.AllowEncode);
+            Assert.Null(effective.Formats.DenyEncode);
+        }
+
+        [Fact]
+        public void DenyEncodeList_MergesWithServerDefault()
+        {
+            var policy = new SecurityPolicyOptions
+            {
+                Formats = new FormatOptions
+                {
+                    DenyEncode = new List<ImageFormat> { ImageFormat.Webp },
+                },
+            };
+            var effective = policy.BuildEffectiveSecurityOptions();
+            Assert.NotNull(effective.Formats!.DenyEncode);
+            Assert.Contains(ImageFormat.Webp, effective.Formats.DenyEncode!);
+            Assert.Contains(ImageFormat.Avif, effective.Formats.DenyEncode!);
+            Assert.Contains(ImageFormat.Jxl, effective.Formats.DenyEncode!);
+        }
+
+        [Fact]
+        public void DenyEncodeList_DuplicatesAreFoldedOut()
+        {
+            var policy = new SecurityPolicyOptions
+            {
+                Formats = new FormatOptions
+                {
+                    DenyEncode = new List<ImageFormat> { ImageFormat.Avif, ImageFormat.Webp },
+                },
+            };
+            var effective = policy.BuildEffectiveSecurityOptions();
+            var avifCount = effective.Formats!.DenyEncode!.Count(f => f == ImageFormat.Avif);
+            Assert.Equal(1, avifCount);
+        }
+
+        [Fact]
+        public void AllowAndDenyForDecode_RaisesValidationException()
+        {
+            var policy = new SecurityPolicyOptions
+            {
+                Formats = new FormatOptions
+                {
+                    AllowDecode = new List<ImageFormat> { ImageFormat.Jpeg },
+                    DenyDecode = new List<ImageFormat> { ImageFormat.Png },
+                },
+            };
+            var ex = Assert.Throws<SecurityPolicyValidationException>(() => policy.Validate());
+            Assert.Contains("decode", ex.Message);
+        }
+
+        [Fact]
+        public void ListAndTable_RaisesValidationException()
+        {
+            var policy = new SecurityPolicyOptions
+            {
+                Formats = new FormatOptions
+                {
+                    AllowDecode = new List<ImageFormat> { ImageFormat.Jpeg },
+                    Formats = new Dictionary<ImageFormat, FormatPermissions>
+                    {
+                        { ImageFormat.Webp, new FormatPermissions(true, true) },
+                    },
+                },
+            };
+            var ex = Assert.Throws<SecurityPolicyValidationException>(() => policy.Validate());
+            Assert.Contains("single form", ex.Message);
+        }
+
+        [Fact]
+        public void CodecAllowAndDeny_RaisesValidationException()
+        {
+            var policy = new SecurityPolicyOptions
+            {
+                Codecs = new CodecOptions
+                {
+                    AllowEncoders = new List<NamedEncoderName> { NamedEncoderName.ZenJpegEncoder },
+                    DenyEncoders = new List<NamedEncoderName> { NamedEncoderName.MozjpegEncoder },
+                },
+            };
+            Assert.Throws<SecurityPolicyValidationException>(() => policy.Validate());
+        }
+
+        [Fact]
+        public void CustomRiskyEncodeList_TakesEffect()
+        {
+            var policy = new SecurityPolicyOptions
+            {
+                ServerRiskyEncode = new[] { ImageFormat.Webp },
+            };
+            var effective = policy.BuildEffectiveSecurityOptions();
+            Assert.NotNull(effective.Formats!.DenyEncode);
+            Assert.Contains(ImageFormat.Webp, effective.Formats.DenyEncode!);
+            Assert.DoesNotContain(ImageFormat.Avif, effective.Formats.DenyEncode!);
+        }
+
+        [Fact]
+        public void Scalars_PassThroughToEffective()
+        {
+            var policy = new SecurityPolicyOptions
+            {
+                MaxDecodeSize = new FrameSizeLimit(8000, 8000, 50f),
+                MaxInputFileBytes = 256 * 1024 * 1024,
+                MaxJsonBytes = 64 * 1024 * 1024,
+            };
+            var effective = policy.BuildEffectiveSecurityOptions();
+            Assert.NotNull(effective.MaxDecodeSize);
+            Assert.Equal(8000u, effective.MaxDecodeSize!.Value.MaxWidth);
+            Assert.Equal(256UL * 1024 * 1024, effective.MaxInputFileBytes);
+            Assert.Equal(64UL * 1024 * 1024, effective.MaxJsonBytes);
+        }
+
+        [Fact]
+        public void CodecDenyEncoders_SurfacesInEffective()
+        {
+            var policy = new SecurityPolicyOptions
+            {
+                Codecs = new CodecOptions
+                {
+                    DenyEncoders = new List<NamedEncoderName> { NamedEncoderName.MozjpegEncoder },
+                },
+            };
+            var effective = policy.BuildEffectiveSecurityOptions();
+            Assert.NotNull(effective.Codecs);
+            Assert.Contains(NamedEncoderName.MozjpegEncoder, effective.Codecs!.DenyEncoders!);
+        }
+    }
+}

--- a/tests/Imageflow.Server.Tests/packages.lock.json
+++ b/tests/Imageflow.Server.Tests/packages.lock.json
@@ -17,6 +17,29 @@
           "System.IO.Pipelines": "4.7.1"
         }
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "0J/9YNXTMWSZP2p2+nvl8p71zpSwokZXZuJW+VjdErkegAnFdO1XlqtA62SJtgVYHdKu3uPxJHcMR/r35HwFBA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "L89DLNuimOghjV3tLx0ArFDwVEJD6+uGB3BMCMX01kaLzXkaXHb2021xOMl2QOxUxbdePKUZsUY7n2UUkycjRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "8.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "8.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
+          "System.Text.Json": "8.0.5"
+        }
+      },
       "Microsoft.Extensions.FileProviders.Embedded": {
         "type": "Direct",
         "requested": "[2.2.0, )",
@@ -62,6 +85,16 @@
         "requested": "[2.4.5, )",
         "resolved": "2.4.5",
         "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
+      },
+      "Xunit.SkippableFact": {
+        "type": "Direct",
+        "requested": "[1.4.13, )",
+        "resolved": "1.4.13",
+        "contentHash": "IyzZNvJEtXGlXrzxDiSbtH5Lyxf4iJdRQADuyjGdDf00LjXRLJwIoezQNFhFGKTMtvk8IIgaSHxW4mAV4O7b8A==",
+        "dependencies": {
+          "Validation": "2.4.18",
+          "xunit.extensibility.execution": "2.4.0"
+        }
       },
       "AWSSDK.Core": {
         "type": "Transitive",
@@ -125,15 +158,6 @@
           "System.Xml.XmlDocument": "4.3.0"
         }
       },
-      "Imageflow.AllPlatforms": {
-        "type": "Transitive",
-        "resolved": "0.15.1",
-        "contentHash": "Oiaeaz+0ZJip+n+0LD05boBiHKHBWVO79Wnitms3GYzjm9kxYqcSnPtQ9QRdUrwlP39dq8vurYtL4dAZaRmliQ==",
-        "dependencies": {
-          "Imageflow.NativeRuntime.All": "2.3.1-rc01",
-          "Imageflow.Net": "0.15.1"
-        }
-      },
       "Imageflow.NativeRuntime.All": {
         "type": "Transitive",
         "resolved": "2.3.1-rc01",
@@ -183,15 +207,6 @@
         "resolved": "2.3.1-rc01",
         "contentHash": "rkUNn0BVgwobB05obVXEtrX4CvOpcIJ2A8InvO2vPJkRYgqjr5+GIKT0ItgCd90K30ozkWIyvG70KxDs/OL/dw=="
       },
-      "Imageflow.Net": {
-        "type": "Transitive",
-        "resolved": "0.15.1",
-        "contentHash": "A+gdXZ4gxl++sjGEQIEh1r4CiRMBM5KD2Y0/993weNSPbfkUu+jrP4nGZ/nAOvjM/eRXFYP/gNnazaxDA2QeeQ==",
-        "dependencies": {
-          "Microsoft.IO.RecyclableMemoryStream": "[3.0.1, 4.0.0)",
-          "System.Text.Json": "8.0.6"
-        }
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -204,10 +219,22 @@
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "65MrmXCziWaQFrI0UHkQbesrX5wTwf9XPjY5yFm/VkgJKFJ5gqvXRoXjIZcf2wLi5ZlwGz/oMYfyURVCWbM5iw==",
+        "resolved": "8.0.0",
+        "contentHash": "3lE/iLSutpgX1CC0NOW70FJoGARRHbyKmG7dc0klnUZ9Dd9hS6N/POPWhKhMLCEuNN5nXEY5agmlFtH562vqhQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "2.2.0"
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "EJzSNO9oaAXnTdtdNO6npPRsIIeZCBSNmdQ091VDO7fBiOtJAAeEq6dtrVXIi3ZyjC5XRSAtVvF8SzcneRHqKQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "8.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -225,11 +252,26 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "EcnaSsPTqx2MGnHrmWOD0ugbuuqVT8iICqSqPzi45V5/MA1LjUNb0kwgcxBGqizV1R+WeBK7/Gw25Jzkyk9bIw==",
+        "resolved": "8.0.0",
+        "contentHash": "ZbaMlhJlpisjuWbvXr4LdAst/1XxH3vZ6A0BsgTphZ2L4PGuxRLz7Jr/S7mkAAnOn78Vu0fKhEgNF5JO3zfjqQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "2.2.0"
+          "Microsoft.Extensions.Primitives": "8.0.0"
         }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "UboiXxpPUpwulHvIAVE36Knq0VSHaAmfrFkegLyBZeaADuKezJ/AIXYAW8F5GBlGk/VaibN2k/Zn1ca8YAfVdA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "OK+670i7esqlQrPjdIKRbsyMCe9g5kSLpRRQGSr4Q58AOYEe/hCnfLZprh7viNisSUUQZmMrbbuDaIrP+V1ebQ=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
@@ -280,8 +322,11 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "cI/VWn9G1fghXrNDagX9nYaaB/nokkZn0HYAawGaELQrl8InSezfe9OnfPZLcJq3esXxygh3hkq2c3qoV3SDyQ=="
+        "resolved": "8.0.0",
+        "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "Microsoft.IO.RecyclableMemoryStream": {
         "type": "Transitive",
@@ -1393,6 +1438,11 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
+      "Validation": {
+        "type": "Transitive",
+        "resolved": "2.4.18",
+        "contentHash": "NfvWJ1QeuZ1FQCkqgXTu1cOkRkbNCfxs4Tat+abXLwom6OXbULVhRGp34BTvVB4XPxj6VIAl7KfLfStXMt/Ehw=="
+      },
       "xunit.abstractions": {
         "type": "Transitive",
         "resolved": "2.0.3",
@@ -1438,10 +1488,18 @@
           "xunit.extensibility.core": "[2.4.1]"
         }
       },
+      "imageflow.net": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.IO.RecyclableMemoryStream": "[3.*, 4.0.0)",
+          "System.Text.Json": "[8.0.6, )"
+        }
+      },
       "imageflow.server": {
         "type": "Project",
         "dependencies": {
-          "Imageflow.AllPlatforms": "[0.15.1, )",
+          "Imageflow.NativeRuntime.All": "[2.3.1-rc01, 4.0.0)",
+          "Imageflow.Net": "[0.1.0--notset, )",
           "Imazen.Common": "[0.1.0--notset, )",
           "System.Text.Json": "[8.0.6, )"
         }
@@ -1526,6 +1584,28 @@
           "System.IO.Pipelines": "4.7.1"
         }
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "0J/9YNXTMWSZP2p2+nvl8p71zpSwokZXZuJW+VjdErkegAnFdO1XlqtA62SJtgVYHdKu3uPxJHcMR/r35HwFBA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "L89DLNuimOghjV3tLx0ArFDwVEJD6+uGB3BMCMX01kaLzXkaXHb2021xOMl2QOxUxbdePKUZsUY7n2UUkycjRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "8.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "8.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0"
+        }
+      },
       "Microsoft.Extensions.FileProviders.Embedded": {
         "type": "Direct",
         "requested": "[2.2.0, )",
@@ -1571,6 +1651,16 @@
         "requested": "[2.4.5, )",
         "resolved": "2.4.5",
         "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
+      },
+      "Xunit.SkippableFact": {
+        "type": "Direct",
+        "requested": "[1.4.13, )",
+        "resolved": "1.4.13",
+        "contentHash": "IyzZNvJEtXGlXrzxDiSbtH5Lyxf4iJdRQADuyjGdDf00LjXRLJwIoezQNFhFGKTMtvk8IIgaSHxW4mAV4O7b8A==",
+        "dependencies": {
+          "Validation": "2.4.18",
+          "xunit.extensibility.execution": "2.4.0"
+        }
       },
       "AWSSDK.Core": {
         "type": "Transitive",
@@ -1634,15 +1724,6 @@
           "System.Xml.XmlDocument": "4.3.0"
         }
       },
-      "Imageflow.AllPlatforms": {
-        "type": "Transitive",
-        "resolved": "0.15.1",
-        "contentHash": "Oiaeaz+0ZJip+n+0LD05boBiHKHBWVO79Wnitms3GYzjm9kxYqcSnPtQ9QRdUrwlP39dq8vurYtL4dAZaRmliQ==",
-        "dependencies": {
-          "Imageflow.NativeRuntime.All": "2.3.1-rc01",
-          "Imageflow.Net": "0.15.1"
-        }
-      },
       "Imageflow.NativeRuntime.All": {
         "type": "Transitive",
         "resolved": "2.3.1-rc01",
@@ -1692,14 +1773,6 @@
         "resolved": "2.3.1-rc01",
         "contentHash": "rkUNn0BVgwobB05obVXEtrX4CvOpcIJ2A8InvO2vPJkRYgqjr5+GIKT0ItgCd90K30ozkWIyvG70KxDs/OL/dw=="
       },
-      "Imageflow.Net": {
-        "type": "Transitive",
-        "resolved": "0.15.1",
-        "contentHash": "A+gdXZ4gxl++sjGEQIEh1r4CiRMBM5KD2Y0/993weNSPbfkUu+jrP4nGZ/nAOvjM/eRXFYP/gNnazaxDA2QeeQ==",
-        "dependencies": {
-          "Microsoft.IO.RecyclableMemoryStream": "[3.0.1, 4.0.0)"
-        }
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -1712,10 +1785,22 @@
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "65MrmXCziWaQFrI0UHkQbesrX5wTwf9XPjY5yFm/VkgJKFJ5gqvXRoXjIZcf2wLi5ZlwGz/oMYfyURVCWbM5iw==",
+        "resolved": "8.0.0",
+        "contentHash": "3lE/iLSutpgX1CC0NOW70FJoGARRHbyKmG7dc0klnUZ9Dd9hS6N/POPWhKhMLCEuNN5nXEY5agmlFtH562vqhQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "2.2.0"
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "EJzSNO9oaAXnTdtdNO6npPRsIIeZCBSNmdQ091VDO7fBiOtJAAeEq6dtrVXIi3ZyjC5XRSAtVvF8SzcneRHqKQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "8.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -1733,11 +1818,26 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "EcnaSsPTqx2MGnHrmWOD0ugbuuqVT8iICqSqPzi45V5/MA1LjUNb0kwgcxBGqizV1R+WeBK7/Gw25Jzkyk9bIw==",
+        "resolved": "8.0.0",
+        "contentHash": "ZbaMlhJlpisjuWbvXr4LdAst/1XxH3vZ6A0BsgTphZ2L4PGuxRLz7Jr/S7mkAAnOn78Vu0fKhEgNF5JO3zfjqQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "2.2.0"
+          "Microsoft.Extensions.Primitives": "8.0.0"
         }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "UboiXxpPUpwulHvIAVE36Knq0VSHaAmfrFkegLyBZeaADuKezJ/AIXYAW8F5GBlGk/VaibN2k/Zn1ca8YAfVdA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "OK+670i7esqlQrPjdIKRbsyMCe9g5kSLpRRQGSr4Q58AOYEe/hCnfLZprh7viNisSUUQZmMrbbuDaIrP+V1ebQ=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
@@ -1788,8 +1888,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "cI/VWn9G1fghXrNDagX9nYaaB/nokkZn0HYAawGaELQrl8InSezfe9OnfPZLcJq3esXxygh3hkq2c3qoV3SDyQ=="
+        "resolved": "8.0.0",
+        "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g=="
       },
       "Microsoft.IO.RecyclableMemoryStream": {
         "type": "Transitive",
@@ -2889,6 +2989,11 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
+      "Validation": {
+        "type": "Transitive",
+        "resolved": "2.4.18",
+        "contentHash": "NfvWJ1QeuZ1FQCkqgXTu1cOkRkbNCfxs4Tat+abXLwom6OXbULVhRGp34BTvVB4XPxj6VIAl7KfLfStXMt/Ehw=="
+      },
       "xunit.abstractions": {
         "type": "Transitive",
         "resolved": "2.0.3",
@@ -2934,10 +3039,17 @@
           "xunit.extensibility.core": "[2.4.1]"
         }
       },
+      "imageflow.net": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.IO.RecyclableMemoryStream": "[3.*, 4.0.0)"
+        }
+      },
       "imageflow.server": {
         "type": "Project",
         "dependencies": {
-          "Imageflow.AllPlatforms": "[0.15.1, )",
+          "Imageflow.NativeRuntime.All": "[2.3.1-rc01, 4.0.0)",
+          "Imageflow.Net": "[0.1.0--notset, )",
           "Imazen.Common": "[0.1.0--notset, )",
           "System.Text.Json": "[8.0.6, )"
         }

--- a/tests/api-surface/Imageflow.Server.txt
+++ b/tests/api-surface/Imageflow.Server.txt
@@ -11,11 +11,29 @@ namespace Imageflow.Server
         LocalHost = 1,
         AnyHost = 2,
     }
+    public sealed class CodecOptions
+    {
+        public CodecOptions() { }
+        public System.Collections.Generic.IList<Imageflow.Fluent.NamedDecoderName>? AllowDecoders { get; set; }
+        public System.Collections.Generic.IList<Imageflow.Fluent.NamedEncoderName>? AllowEncoders { get; set; }
+        public System.Collections.Generic.IList<Imageflow.Fluent.NamedDecoderName>? DenyDecoders { get; set; }
+        public System.Collections.Generic.IList<Imageflow.Fluent.NamedEncoderName>? DenyEncoders { get; set; }
+    }
     public enum EnforceLicenseWith
     {
         RedDotWatermark = 0,
         Http422Error = 1,
         Http402Error = 2,
+    }
+    public sealed class FormatOptions
+    {
+        public FormatOptions() { }
+        public System.Collections.Generic.IList<Imageflow.Fluent.ImageFormat>? AllowDecode { get; set; }
+        public System.Collections.Generic.IList<Imageflow.Fluent.ImageFormat>? AllowEncode { get; set; }
+        public System.Collections.Generic.IList<Imageflow.Fluent.ImageFormat>? DenyDecode { get; set; }
+        public System.Collections.Generic.IList<Imageflow.Fluent.ImageFormat>? DenyEncode { get; set; }
+        public System.Collections.Generic.IDictionary<Imageflow.Fluent.ImageFormat, Imageflow.Fluent.FormatPermissions>? Formats { get; set; }
+        public System.Collections.Generic.IList<Imageflow.Fluent.ImageFormat>? OptInEncode { get; set; }
     }
     public class ImageflowMiddleware
     {
@@ -33,12 +51,14 @@ namespace Imageflow.Server
         public bool AllowDiskCaching { get; set; }
         public bool ApplyDefaultCommandsToQuerylessUrls { get; set; }
         public string DefaultCacheControlString { get; set; }
+        public bool ExposeNetSupportHeader { get; set; }
         public Imageflow.Fluent.SecurityOptions JobSecurityOptions { get; set; }
         public bool MapWebRoot { get; set; }
         public System.Collections.Generic.IReadOnlyCollection<Imageflow.Server.PathMapping> MappedPaths { get; }
         public string MyOpenSourceProjectUrl { get; set; }
         public System.Collections.Generic.IReadOnlyCollection<Imageflow.Server.NamedWatermark> NamedWatermarks { get; }
         public Imageflow.Server.RequestSignatureOptions RequestSignatureOptions { get; set; }
+        public Imageflow.Server.SecurityPolicyOptions SecurityPolicyOptions { get; set; }
         public bool UsePresetsExclusively { get; set; }
         public Imageflow.Server.ImageflowMiddlewareOptions AddCommandDefault(string key, string value) { }
         public Imageflow.Server.ImageflowMiddlewareOptions AddPostRewriteAuthorizationHandler(string pathPrefix, System.Func<Imageflow.Server.UrlEventArgs, bool> handler) { }
@@ -56,11 +76,13 @@ namespace Imageflow.Server
         public Imageflow.Server.ImageflowMiddlewareOptions SetDefaultCacheControlString(string cacheControlString) { }
         public Imageflow.Server.ImageflowMiddlewareOptions SetDiagnosticsPageAccess(Imageflow.Server.AccessDiagnosticsFrom accessDiagnosticsFrom) { }
         public Imageflow.Server.ImageflowMiddlewareOptions SetDiagnosticsPagePassword(string password) { }
+        public Imageflow.Server.ImageflowMiddlewareOptions SetExposeNetSupportHeader(bool value) { }
         public Imageflow.Server.ImageflowMiddlewareOptions SetJobSecurityOptions(Imageflow.Fluent.SecurityOptions securityOptions) { }
         public Imageflow.Server.ImageflowMiddlewareOptions SetLicenseKey(Imageflow.Server.EnforceLicenseWith enforcementMethod, string licenseKey) { }
         public Imageflow.Server.ImageflowMiddlewareOptions SetMapWebRoot(bool value) { }
         public Imageflow.Server.ImageflowMiddlewareOptions SetMyOpenSourceProjectUrl(string myOpenSourceProjectUrl) { }
         public Imageflow.Server.ImageflowMiddlewareOptions SetRequestSignatureOptions(Imageflow.Server.RequestSignatureOptions options) { }
+        public Imageflow.Server.ImageflowMiddlewareOptions SetSecurityPolicyOptions(Imageflow.Server.SecurityPolicyOptions policyOptions) { }
         public Imageflow.Server.ImageflowMiddlewareOptions SetUsePresetsExclusively(bool value) { }
     }
     public class NamedWatermark
@@ -101,6 +123,39 @@ namespace Imageflow.Server
     {
         public RequestSignatureOptions(Imageflow.Server.SignatureRequired defaultRequirement, System.Collections.Generic.IEnumerable<string> defaultSigningKeys) { }
         public Imageflow.Server.RequestSignatureOptions ForPrefix(string prefix, System.StringComparison prefixComparison, Imageflow.Server.SignatureRequired requirement, System.Collections.Generic.IEnumerable<string> signingKeys) { }
+    }
+    public static class SecurityPolicyConfigurationBinder
+    {
+        public const string DefaultSectionPath = "Imageflow:Security";
+        public static Imageflow.Server.SecurityPolicyOptions? Bind(Microsoft.Extensions.Configuration.IConfiguration section) { }
+    }
+    public sealed class SecurityPolicyOptions
+    {
+        public static readonly System.Collections.Generic.IReadOnlyList<Imageflow.Fluent.ImageFormat> ServerRiskyEncodeDefault;
+        public SecurityPolicyOptions() { }
+        public Imageflow.Server.CodecOptions? Codecs { get; set; }
+        public Imageflow.Server.FormatOptions? Formats { get; set; }
+        public Imageflow.Fluent.FrameSizeLimit? MaxDecodeSize { get; set; }
+        public Imageflow.Fluent.FrameSizeLimit? MaxEncodeSize { get; set; }
+        public Imageflow.Fluent.FrameSizeLimit? MaxFrameSize { get; set; }
+        public ulong? MaxInputFileBytes { get; set; }
+        public ulong? MaxJsonBytes { get; set; }
+        public ulong? MaxTotalFilePixels { get; set; }
+        public System.Collections.Generic.IReadOnlyList<Imageflow.Fluent.ImageFormat> ServerRiskyEncode { get; set; }
+        public Imageflow.Fluent.SecurityOptions BuildEffectiveSecurityOptions() { }
+        public void Validate() { }
+    }
+    public sealed class SecurityPolicyValidationException : System.Exception
+    {
+        public SecurityPolicyValidationException(string message) { }
+        public SecurityPolicyValidationException(string message, System.Exception inner) { }
+    }
+    public sealed class SecurityPolicyValidator
+    {
+        public SecurityPolicyValidator() { }
+        public Imageflow.Fluent.SecurityOptions? EffectiveJobSecurity { get; }
+        public Imageflow.Bindings.NetSupportResponse? EffectiveNetSupport { get; }
+        public void Apply(Imageflow.Server.SecurityPolicyOptions options, Microsoft.Extensions.Logging.ILogger? logger = null) { }
     }
     public enum SignatureRequired
     {


### PR DESCRIPTION
## Motivation

Companion to [imazen/imageflow#720](https://github.com/imazen/imageflow/pull/720) (Rust: `v1/context/set_policy`, format/codec killbits) and [imazen/imageflow-dotnet#68](https://github.com/imazen/imageflow-dotnet/pull/68) (C# bindings for the killbits surface). This PR wires the killbits into the Imageflow.Server middleware so operators can narrow decode/encode through configuration rather than code changes.

A companion PR exists for the Rust server ([imazen/imageflow-server-rs#14](https://github.com/imazen/imageflow-server-rs/pull/14)); this is the C# server equivalent.

## What this adds

### Configuration surface

`Imageflow:Security` block in `appsettings.json`, bound via `SecurityPolicyConfigurationBinder.Bind(configuration.GetSection(\"Imageflow:Security\"))`:

```jsonc
{
  \"Imageflow\": {
    \"Security\": {
      \"MaxDecodeSize\": { \"W\": 8000, \"H\": 8000, \"Megapixels\": 50 },
      \"MaxInputFileBytes\": 268435456,
      \"MaxJsonBytes\": 67108864,
      \"Formats\": {
        \"OptInEncode\": [ \"avif\", \"jxl\" ],
        \"DenyEncode\":  [ \"webp\" ]
      },
      \"Codecs\": {
        \"DenyEncoders\": [ \"mozjpeg_encoder\" ]
      }
    }
  }
}
```

Three mutually-exclusive form families for `Formats`: allow-list, deny-list, or per-format table. `SecurityPolicyConfigurationBinder` validates mutual exclusion and unknown format/codec names at bind time and raises `SecurityPolicyValidationException` with the offending path.

### Server-default AVIF / JXL opt-in

AVIF and JXL encode are denied by default (\"risky-encode list\"), even when the native build supports them. Operators must opt in explicitly:

| Config                                      | Effective deny_encode           |
|---------------------------------------------|---------------------------------|
| No `Formats` block                          | `[avif, jxl]`                   |
| `OptInEncode: [avif]`                       | `[jxl]`                         |
| `OptInEncode: [avif, jxl]`                  | (none)                          |
| `AllowEncode: [jpeg, png]`                  | (server default disabled)       |
| `Formats.avif.Encode: true` (table form)    | table injects `jxl.Encode=false`|

Explicit mention of a risky format — via `AllowEncode`, `DenyEncode`, or a table entry — disables the server default for that format.

The default list is public (`SecurityPolicyOptions.ServerRiskyEncodeDefault`) and can be overridden via `ServerRiskyEncode` in config for specialized deployments.

### Startup integration

- Bind into `SecurityPolicyOptions` and call `options.SetSecurityPolicyOptions(policy)`.
- Middleware constructor instantiates a `SecurityPolicyValidator`, which runs `SetPolicy` on a scratch `JobContext` to validate the policy and capture the `NetSupportResponse` grid.
- Single structured log line tagged `killbits-policy` summarizing effective decode/encode sets — `grep killbits-policy` to diagnose \"why not WebP?\".
- Invalid policy = startup failure. No silent degraded mode.

### Per-request handling

- Narrowing-only effective `SecurityOptions` is merged with the legacy `JobSecurityOptions` and attached to every job via `FinishJobBuilder.SetSecurityOptions`.
- `KillbitsDeniedException` → HTTP 422 with structured JSON body: `{ \"error\": \"encode_not_available\", \"format\": \"avif\", \"reasons\": [...] }`.
- Optional `X-Imageflow-Net-Support` header, off by default (`SetExposeNetSupportHeader(true)` to enable).

### Caching architecture

| Layer                           | Scope                  | Invalidation |
|---------------------------------|------------------------|--------------|
| `NetSupportResponse` grid       | Middleware singleton   | Never (set-once) |
| `SecurityOptions` (effective)   | Middleware singleton   | Never (set-once) |
| MIME types / extensions         | `ImageflowCapabilities` (process-global, from imageflow-dotnet) | Never |
| `SecurityPolicyOptions`         | DI singleton (operator-owned) | Never (no hot-reload) |

Thread-safe via `Lazy<T>` and populate-at-startup-then-readonly patterns. Per-request code path makes zero native round-trips to fetch the policy.

## Dependency pins

Dev-time: `src/Imageflow.Server/Imageflow.Server.csproj` replaces `Imageflow.AllPlatforms` with a `ProjectReference` to `../../../imageflow-dotnet/src/Imageflow/Imageflow.Net.csproj` (feat/killbits-dotnet-surface branch) plus `Imageflow.NativeRuntime.All [2.3.1-rc01, 4.0.0)`. The csproj has an inline comment explaining the flip-to-package-ref sequence once v3 prereleases ship.

## Breaking change

Servers upgrading past the killbits release will see **AVIF and JXL encode requests begin failing with 422** until operators add `OptInEncode: [avif, jxl]` (or equivalent) to their config. Decode behavior is unchanged.

This is called out deliberately in `docs/killbits.md`. The security posture improvement (opt-in rather than opt-out for formats with historically higher attack surface) outweighs the migration cost for operators.

## Test plan

Run locally:
```bash
cd tests/Imageflow.Server.Tests
dotnet test -f net8.0
```

- [x] 22 `SecurityPolicyOptionsTests` + `SecurityPolicyConfigurationBinderTests` — pass on net8 (net6 requires the .NET 6 runtime; CI covers both)
- [x] 38 existing `IntegrationTest` assertions — still pass (no regression)
- [ ] 3 `KillbitsIntegrationTest` end-to-end tests — gated behind `IMAGEFLOW_TESTS_KILLBITS_NATIVE=1`. CI workflow should flip the flag once a native runtime with imageflow#720 ships as an `Imageflow.NativeRuntime.All` v3 prerelease.
- [x] `tests/api-surface/Imageflow.Server.txt` regenerated and committed.
- [x] PublicAPI.Unshipped.txt lists every new symbol.

## Draft status

This PR is **draft — do not merge**:

1. Blocked on imazen/imageflow#720 merging.
2. Blocked on imazen/imageflow-dotnet#68 merging.
3. Blocked on an `Imageflow.AllPlatforms` v3 prerelease that carries the `set_policy` / `get_net_support` endpoints.

Once all three land, flip the csproj `ProjectReference` back to a `PackageReference` with the released version range, run the gated integration tests against the new native, and move out of draft.